### PR TITLE
docs(rightsizing-peak): correct Advisor methodology framing

### DIFF
--- a/docs/build_overview_pptx.py
+++ b/docs/build_overview_pptx.py
@@ -177,7 +177,7 @@ def slide_title(prs):
 
     add_text(s, Inches(1.0), Inches(4.4),
              Inches(11.5), Inches(0.6),
-             "Replace Advisor's averages.  Find the waste it can't price.  "
+             "Beat Advisor's 7-day window.  Find the waste it can't price.  "
              "Own the buffer.",
              size=20, color=AMBER)
 
@@ -205,7 +205,8 @@ def slide_problem(prs):
 
     add_card(s, Inches(0.5), Inches(1.7), Inches(4.0), Inches(4.6),
              "Azure Advisor",
-             ["Uses averages — unsafe on bursty / batch workloads.",
+             ["7-day default window + 30-min max-of-avg buckets miss "
+              "weekly / month-end / sub-30-min peaks.",
               "Ignores orphan waste (snapshots, empty plans, idle LBs).",
               "No owner routing. Findings die in a portal tab.",
               "No buffer-aware RI guidance."],
@@ -241,7 +242,8 @@ def slide_answer(prs):
 
     cards = [
         ("rightsizing-peak",
-         ["P95 / P99 instead of averages.",
+         ["30-day window + per-hour true-peak P95 / P99 "
+          "(vs Advisor's 7-day / 30-min max-of-avg).",
           "Flags Advisor's unsafe downsizes.",
           "Tunable thresholds per run."],
          TEAL),
@@ -322,9 +324,10 @@ def slide_rightsizing(prs):
     slide_engine(
         prs,
         eyebrow="ENGINE 1 / 4",
-        title="rightsizing-peak — peak beats average, every time.",
-        lead="Replaces Advisor's average-based downsize logic with "
-             "P95 / P99 peak-aware decisions.",
+        title="rightsizing-peak — longer window, sharper peaks.",
+        lead="Advisor already uses P95/P99, but on a 7-day default "
+             "window with 30-min max-of-avg buckets. This engine uses "
+             "30 days + per-hour true peaks.",
         points=[
             "30 days of per-hour Max CPU + Min memory from Azure Monitor.",
             "Per-VM verdict: DOWNSIZE / KEEP / UPSIZE_WARNING / "

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -110,7 +110,15 @@ engines' CSV output is easy to ingest into the toolkit's Power BI models.
 
 Advisor is a great starting point. It misses:
 
-- **Peak-aware rightsizing** (Advisor uses averages).
+- **Longer-window, per-hour-true-peak rightsizing.** Advisor already
+  uses P95 / P99 (not averages — a common misconception driven by the
+  portal's *average CPU utilization* display filter), but on a 7-day
+  default window with 30-min buckets taken as the max of 1-minute
+  averages. `rightsizing-peak` uses 30 days and per-hour `Maximum` CPU
+  / `Minimum` `Available Memory Bytes` buckets, which catches weekly,
+  month-end, and sub-30-minute peaks the 7-day / 30-min view smooths
+  over. See
+  [`tools/rightsizing-peak/README.md`](../tools/rightsizing-peak/README.md#why-peak-aware-matters--and-where-advisor-falls-short).
 - **Old snapshots, empty App Service Plans, idle Standard LBs,
   stopped-not-deallocated VMs** as priced findings.
 - **A coverage-gap-with-buffer-guardrail** approach to RI/SP commits.

--- a/samples/peak-rightsizing/peak-rightsizing-combined-20260101.md
+++ b/samples/peak-rightsizing/peak-rightsizing-combined-20260101.md
@@ -29,9 +29,13 @@ The unsafe Advisor recommendation in this run:
 |-------------------------------|--------------------|------------------|--------:|--------:|
 | `vm-batch-night-04`           | Resize → D4s_v5    | UPSIZE_WARNING   |    91 % |    78 % |
 
-The VM looks idle on Advisor's average (which is dragged down by 22 hours
-per day of zero load) but saturates CPU during a 02:00–04:00 batch window.
-Resizing it down per Advisor would have caused the batch SLA to slip.
+The VM looks idle on Advisor's default 7-day window with 30-min buckets
+(the night-batch window only contributes a handful of buckets, and
+Advisor's bucketing is the *max of 1-minute averages* rather than a
+true peak — the 02:00–04:00 saturation is smoothed by 22 hours of
+near-zero load on either side). The 30-day per-hour-`Maximum` view
+this engine uses keeps every saturated batch hour visible in the P95.
+Resizing this VM down per Advisor would have caused the batch SLA to slip.
 
 ## Per-subscription reports
 

--- a/tools/rightsizing-peak/README.md
+++ b/tools/rightsizing-peak/README.md
@@ -1,9 +1,25 @@
 # rightsizing-peak
 
-Peak-aware (P95 / P99) VM rightsizing engine. A safe replacement for Azure
-Advisor's average-based "Cost — Resize Virtual Machine" recommendations,
-appropriate for spiky / batch / retail workloads where Advisor's averages
-hide the peak that justifies the current SKU.
+Peak-aware (P95 / P99) VM rightsizing engine. A safer companion to Azure
+Advisor's "Cost — Resize Virtual Machine" recommendations for spiky /
+batch / retail / month-end workloads where Advisor's default 7-day
+lookback and 30-min bucketed aggregation hide the peak that justifies
+the current SKU.
+
+> **Common misconception:** Advisor does **not** use simple averages. Per
+> [Microsoft Learn][advisor-resize] its resize algorithm uses **P95 of
+> CPU and Outbound Network** and **P99 of Memory** on a 7-day default
+> window, with samples bucketed into 30-minute intervals taken as the
+> *max of 1-minute averages*. The headline value of `rightsizing-peak`
+> is therefore **not** "P95 vs averages" — it is **(a)** a 30-day
+> default window that catches weekly / month-end peaks Advisor's 7-day
+> window misses, **(b)** per-hour true `Maximum` CPU and per-hour
+> `Minimum` `Available Memory Bytes` (a stricter bucketing than
+> Advisor's max-of-1-min-averages), **(c)** explicit exclusion of
+> AKS / Databricks-managed VMs, and **(d)** a deterministic Advisor-diff
+> that flags any of Advisor's downsizes this engine would deem unsafe.
+
+[advisor-resize]: https://learn.microsoft.com/azure/advisor/advisor-cost-recommendations#resize-sku-recommendations
 
 ## What it does
 
@@ -165,25 +181,52 @@ defers the choice to the human reviewer. Adding ladder entries is the
 recommended way to expand the engine's coverage; heuristic-derived targets
 are deliberately not generated.
 
-## Why peak-aware matters
+## Why peak-aware matters — and where Advisor falls short
 
-Advisor's "Cost — Resize" recommendation is derived from the *average* CPU
-over its observation window. For a steady-state workload that is fine. For:
+Advisor's resize algorithm already uses percentiles, **not** averages. The
+documented thresholds (per [Microsoft Learn][advisor-resize]) are:
 
-- **Retail batch jobs** that idle 90% of the day and saturate at 02:00,
-- **CI runners** that burst during the working day,
-- **Reporting / ETL** that hit one peak per month,
+| Workload class | CPU & Outbound Network | Memory |
+|---|---|---|
+| User-facing | **P95 ≤ 40 %** on the new SKU | **P99 ≤ 60 %** on the new SKU |
+| Non-user-facing | P95 ≤ 80 % | P99 ≤ 80 % |
 
-…the *average* is structurally below 40% but the *peak* is at 100%. Following
-Advisor's recommendation in those cases causes a missed peak — a pager event
-that has nothing to do with the change reviewer realising they bought 12
-months of pain to save £40 / month.
+`rightsizing-peak` uses similar P95 / P99 thresholds. The genuine, defensible
+deltas are **window length** and **bucket aggregation**:
+
+| Dimension | Azure Advisor | `rightsizing-peak` |
+|---|---|---|
+| Default lookback | **7 days** (configurable 7 / 14 / 21 / 30 / 60 / 90) | **30 days** (configurable via `--days`) |
+| CPU sampling | every 30 s → 1-min avg → 30-min bucket = **max of 1-min averages** | every 30 s → 1-min avg → 1-hour bucket = **true `Maximum`** |
+| Memory sampling | same 30-min max-of-1-min-averages bucketing | 1-hour `Minimum` of `Available Memory Bytes` (worst-case headroom) |
+| Excludes managed VMs (AKS / Databricks) | No | Yes |
+| Cross-checks Advisor recs as a sanity layer | n/a | Yes — emits `advisor_unsafe = true` |
+
+The portal *VM/VMSS right-sizing* configuration page lets operators filter
+recommendations by an *average CPU utilization* threshold, but that is a
+**display filter**, not the generation algorithm — a common source of the
+"Advisor uses averages" misconception.
+
+Where this matters in practice:
+
+- **Retail batch jobs** that idle 90 % of the day and saturate at 02:00.
+  A 7-day window that happens to omit two of those nights still produces a
+  P95 below 40 %.
+- **Month-end finance / reporting / ETL** workloads that peak once every
+  28–31 days. By definition, a 7-day window will see the peak in at most
+  one run out of four.
+- **CI runners and weekly batch jobs** whose peak weekday isn't always in
+  the 7-day window.
+
+The 30-day default catches these. The per-hour true-peak aggregation
+catches sub-30-minute spikes that Advisor's 30-min max-of-averages
+smooths over.
 
 The engine's headline number — *Advisor recs that would have been unsafe* —
 is therefore the metric that matters most when introducing this tool to a
-new team. Expect 1–5% of Advisor's "downsize" recommendations to be unsafe
-in any given tenant; the cost of one unsafe change typically dwarfs years
-of savings from the safe ones.
+new team. Expect 1–5 % of Advisor's downsize recommendations to be unsafe
+on a longer window in any given tenant; the cost of one unsafe change
+typically dwarfs years of savings from the safe ones.
 
 ## Limitations & assumptions
 

--- a/tools/rightsizing-peak/rightsizing_peak.py
+++ b/tools/rightsizing-peak/rightsizing_peak.py
@@ -2,8 +2,16 @@
 """
 rightsizing-peak — Peak-aware VM rightsizing engine.
 
-Replaces Azure Advisor's average-based rightsizing logic with a P95/P99
-peak-aware decision tree, suitable for spiky retail and batch workloads.
+A longer-window, per-hour-true-peak companion to Azure Advisor's
+"Cost — Resize Virtual Machine" recommendations.
+
+Advisor already uses P95/P99 (see Microsoft Learn:
+advisor-cost-recommendations#resize-sku-recommendations) but on a 7-day
+default window with 30-min buckets taken as the max of 1-minute averages.
+This engine uses a 30-day default window with per-hour `Maximum` CPU and
+per-hour `Minimum` available-memory bucketing, and is suitable for spiky
+retail, batch, CI, and month-end workloads where Advisor's shorter window
+or coarser bucketing can hide a peak that justifies the current SKU.
 
 WHAT IT DOES
 ------------

--- a/tools/rightsizing-peak/workbook-peak-rightsizing.json
+++ b/tools/rightsizing-peak/workbook-peak-rightsizing.json
@@ -5,7 +5,7 @@
     {
       "type": 1,
       "content": {
-        "json": "# FinOps Engine — Peak-Aware Rightsizing\n\nWorkload-aware (P95 / P99) rightsizing dashboard for the FinOps team. Replaces Azure Advisor's average-based logic for spiky / batch workloads. Source: `rightsizing-peak` engine."
+        "json": "# FinOps Engine — Peak-Aware Rightsizing\n\nWorkload-aware (P95 / P99) rightsizing dashboard for the FinOps team. Longer-window, per-hour-true-peak companion to Azure Advisor's resize logic for spiky / batch / month-end workloads where Advisor's 7-day default window or 30-min bucket aggregation hides the peak. Source: `rightsizing-peak` engine."
       },
       "name": "title"
     },


### PR DESCRIPTION
## What

Text-only correction across the rightsizing-peak narrative. Previously claimed Azure Advisor uses `average`-based resize logic; that's wrong. Per [Microsoft Learn](https://learn.microsoft.com/azure/advisor/advisor-cost-recommendations#resize-sku-recommendations), Advisor uses:

- **P95** of CPU & Outbound Network
- **P99** of Memory
- **7-day default window**
- **30-min buckets** taken as the **max of 1-minute averages**

## Why this matters

The value prop of `rightsizing-peak` is now framed around its actual deltas vs Advisor (not a fictional 'we use peaks, they use averages' contrast):

- Longer **30-day** default window
- **Per-hour `Maximum` CPU** / **`Minimum` `Available Memory Bytes`** bucketing
- Exclusion of **AKS / Databricks-managed VMs**
- The deterministic **Advisor-diff**

## Files

- `docs/build_overview_pptx.py` ΓÇö deck generator copy
- `docs/faq.md`  
- `samples/peak-rightsizing/peak-rightsizing-combined-20260101.md` ΓÇö synthetic sample narrative
- `tools/rightsizing-peak/README.md`  
- `tools/rightsizing-peak/rightsizing_peak.py` ΓÇö docstring only
- `tools/rightsizing-peak/workbook-peak-rightsizing.json` ΓÇö workbook subtitle

## Out of scope

**No algorithm or output changes.** `pytest tests/` still 23 / 23 green.