### PR TITLE
feat(context-enricher): --plan-only dry-run mode (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ as detailed in [`VERSIONING.md`](./VERSIONING.md).
 
 ### Added
 
+- **`context-enricher`: `--plan-only` dry-run mode (issue [#21](https://github.com/prbeegala/FinOpsEngine/issues/21)).**
+  When the flag is set, per-owner Issue bodies are written to
+  `<out-dir>/issues-planned/` instead of `<out-dir>/issues/` and each
+  body carries a `> ⚠️ DRY-RUN — --plan-only mode.` banner. The
+  nightly workflow's `gh issue create` loop globs `issues/*.md`, so a
+  plan-only run is a no-op for CI — reviewers can grep
+  `issues-planned/` before flipping the flag off. The
+  `finops-nightly.yml` workflow gains a `plan_only` `workflow_dispatch`
+  input (default `true`) that wires through to the engine and
+  short-circuits the issue-create step. Recommended posture for the
+  first run on a new tenant.
+
 - **`hidden-waste`: PaaS rightsizing — under-utilised App Service Plans
   and idle Container Apps (issue [#4](https://github.com/prbeegala/FinOpsEngine/issues/4)).**
   Adds `idle_app_service_plan` (paid SKUs only — `Free` / `Shared` /

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,7 +126,7 @@ These should land before the engine is rolled out widely.
 - 🛡 🟡 **Output-schema versioning** — version the CSV/MD output formats so
   Workbooks and downstream Issue templates don't break silently when a
   column is added or renamed.
-- 🛡 🟢 **context-enricher `--plan-only` dry-run** — write planned Issue
+- 🛡 🟢 ~~**context-enricher `--plan-only` dry-run**~~ — *delivered in [#21](https://github.com/prbeegala/FinOpsEngine/issues/21).* write planned Issue
   bodies to disk for review *before* opening real GitHub Issues. The
   current path will happily open hundreds of issues in one run.
 

--- a/automation/finops-nightly.yml
+++ b/automation/finops-nightly.yml
@@ -36,6 +36,11 @@ on:
         description: "Comma-separated subscription IDs (defaults to FINOPS_SUBS var)"
         required: false
         type: string
+      plan_only:
+        description: "Dry-run: write planned Issue bodies to issues-planned/ and skip gh issue create. Recommended for the first run on a new tenant."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   id-token: write       # OIDC for `azure/login`.
@@ -110,6 +115,9 @@ jobs:
           ARGS="--out-dir $OUT_BASE/Enriched"
           [ -n "$HIDDEN_CSV" ] && ARGS="$ARGS --hidden-waste-csv $HIDDEN_CSV"
           [ -n "$RIGHT_CSV"  ] && ARGS="$ARGS --rightsizing-csv $RIGHT_CSV"
+          if [ "${{ inputs.plan_only }}" = "true" ]; then
+            ARGS="$ARGS --plan-only"
+          fi
 
           if [ -z "$HIDDEN_CSV" ] && [ -z "$RIGHT_CSV" ]; then
             echo "::warning::No engine CSVs found — skipping enrichment."
@@ -126,7 +134,7 @@ jobs:
           retention-days: 30
 
       - name: Open / update per-owner issues
-        if: success()
+        if: success() && inputs.plan_only != true
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
@@ -144,6 +152,12 @@ jobs:
                 --label "finops,auto-generated" || true
             fi
           done
+
+      - name: Plan-only summary
+        if: success() && inputs.plan_only == true
+        run: |
+          echo "::notice::PLAN-ONLY run — Issue bodies written to issues-planned/. No GitHub Issues opened. Re-run with plan_only=false to publish."
+          ls -lah "$OUT_BASE"/Enriched/issues-planned/ 2>/dev/null || true
 
       - name: Headline summary
         if: success()

--- a/tests/test_context_enricher_plan_only.py
+++ b/tests/test_context_enricher_plan_only.py
@@ -1,0 +1,101 @@
+"""Tests for ``context-enricher --plan-only`` dry-run mode (issue #21)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+FIX = Path(__file__).resolve().parent / "fixtures" / "context-enricher" / "input"
+
+
+def _patch_tags(monkeypatch, mod) -> None:
+    raw = json.loads((FIX / "tags.json").read_text(encoding="utf-8"))
+    tag_map = {k.lower(): v for k, v in raw.items() if not k.startswith("_")}
+    monkeypatch.setattr(mod, "fetch_tags_for_ids", lambda _ids: tag_map)
+
+
+def test_plan_only_writes_to_issues_planned_not_issues(
+    context_enricher, tmp_path, monkeypatch
+):
+    _patch_tags(monkeypatch, context_enricher)
+
+    context_enricher.run(
+        hidden_waste_csv=FIX / "hidden-waste.csv",
+        rightsizing_csv=None,
+        out_dir=tmp_path,
+        plan_only=True,
+    )
+
+    planned = tmp_path / "issues-planned"
+    issues = tmp_path / "issues"
+
+    assert planned.exists() and planned.is_dir(), \
+        "plan-only should create out/issues-planned/"
+    bodies = list(planned.glob("*.md"))
+    assert bodies, "plan-only should still write per-owner Issue bodies"
+    assert not issues.exists() or not list(issues.glob("*.md")), \
+        "plan-only must NOT write into issues/ — the workflow globs that path"
+
+
+def test_plan_only_bodies_carry_dry_run_banner(
+    context_enricher, tmp_path, monkeypatch
+):
+    _patch_tags(monkeypatch, context_enricher)
+    context_enricher.run(
+        hidden_waste_csv=FIX / "hidden-waste.csv",
+        rightsizing_csv=None,
+        out_dir=tmp_path,
+        plan_only=True,
+    )
+    bodies = list((tmp_path / "issues-planned").glob("*.md"))
+    assert bodies
+    for b in bodies:
+        text = b.read_text(encoding="utf-8")
+        assert "DRY-RUN" in text and "--plan-only" in text, \
+            f"missing dry-run banner in {b.name}:\n{text[:200]}"
+
+
+def test_default_run_writes_to_issues_no_banner(
+    context_enricher, tmp_path, monkeypatch
+):
+    _patch_tags(monkeypatch, context_enricher)
+    context_enricher.run(
+        hidden_waste_csv=FIX / "hidden-waste.csv",
+        rightsizing_csv=None,
+        out_dir=tmp_path,
+    )
+
+    issues = tmp_path / "issues"
+    planned = tmp_path / "issues-planned"
+    assert issues.exists()
+    bodies = list(issues.glob("*.md"))
+    assert bodies, "default run should write per-owner bodies under issues/"
+    assert not planned.exists(), \
+        "default run must NOT create issues-planned/"
+    for b in bodies:
+        assert "DRY-RUN" not in b.read_text(encoding="utf-8")
+
+
+def test_plan_only_prints_summary(
+    context_enricher, tmp_path, monkeypatch, capsys
+):
+    _patch_tags(monkeypatch, context_enricher)
+    context_enricher.run(
+        hidden_waste_csv=FIX / "hidden-waste.csv",
+        rightsizing_csv=None,
+        out_dir=tmp_path,
+        plan_only=True,
+    )
+    out = capsys.readouterr().out
+    assert "PLAN-ONLY" in out
+    assert "no GitHub Issues" in out
+
+
+def test_plan_only_cli_flag_present(context_enricher):
+    """--plan-only must be wired into argparse so `--help` documents it."""
+    import argparse
+    src = Path(context_enricher.__file__).read_text(encoding="utf-8")
+    assert "--plan-only" in src
+    assert "issues-planned" in src

--- a/tools/context-enricher/README.md
+++ b/tools/context-enricher/README.md
@@ -55,6 +55,27 @@ python context_enricher.py `
 `az login` required. ~3–8 minutes per 1 500 findings (rate-limited by
 Resource Graph, not Cost Management — much faster than `hidden-waste`).
 
+### Dry-run / plan-only mode
+
+Add `--plan-only` to write the planned per-owner Issue bodies to
+`<out-dir>/issues-planned/` instead of `<out-dir>/issues/` and skip
+the actual Issue creation in CI:
+
+```pwsh
+python context_enricher.py `
+  --hidden-waste-csv ./out/hidden-waste/hidden-waste-<date>.csv `
+  --out-dir ./out/enriched `
+  --plan-only
+```
+
+This is the **recommended posture for the first run on a new tenant** —
+the nightly workflow's `gh issue create` step globs `issues/*.md`, so
+writing into `issues-planned/` is a no-op for CI. Reviewers can grep
+the directory and confirm the bodies look sane before re-running
+without the flag (or with `plan_only=false` from `workflow_dispatch`).
+Each body carries a `> ⚠️ DRY-RUN — --plan-only mode.` banner so
+operators can't accidentally treat a planned body as a published one.
+
 ## Outputs
 
 - `enriched-<date>.csv` — every finding with owner / criticality / env /
@@ -63,6 +84,8 @@ Resource Graph, not Cost Management — much faster than `hidden-waste`).
 - `issues/<owner-slug>-<date>.md` — per-owner Issue body, ready for
   `gh issue create -F`. Each body links back to the source engine and
   asks for `accept` / `defer` / `reject` replies per row.
+- `issues-planned/<owner-slug>-<date>.md` — same content, dry-run
+  banner, written only when `--plan-only` is set.
 
 ## Customising the tag taxonomy
 

--- a/tools/context-enricher/context_enricher.py
+++ b/tools/context-enricher/context_enricher.py
@@ -385,12 +385,19 @@ def write_summary_md(path: Path, findings: list[Finding]) -> None:
     path.write_text("\n".join(L), encoding="utf-8")
 
 
-def write_owner_issue(path: Path, owner: str, items: list[Finding]) -> None:
+def write_owner_issue(path: Path, owner: str, items: list[Finding],
+                      *, plan_only: bool = False) -> None:
     items = sorted(items, key=lambda x: -x.monthly_gbp)
     monthly = sum(f.monthly_gbp for f in items)
     annual  = monthly * 12
 
     L = []
+    if plan_only:
+        L.append("> ⚠️ **DRY-RUN — `--plan-only` mode.** No GitHub Issue was "
+                 "opened for this body. To actually open Issues, re-run "
+                 "without `--plan-only` (engine) or with the workflow input "
+                 "`plan_only=false` (CI).")
+        L.append("")
     L.append(f"## FinOps remediation queue — {owner or 'Unowned'}")
     L.append("")
     L.append(f"**{len(items)} findings · ~£{monthly:,.0f} / month "
@@ -441,9 +448,17 @@ def write_owner_issue(path: Path, owner: str, items: list[Finding]) -> None:
 
 def run(hidden_waste_csv: Path | None,
         rightsizing_csv: Path | None,
-        out_dir: Path) -> None:
+        out_dir: Path,
+        *,
+        plan_only: bool = False) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
-    issues_dir = out_dir / "issues"
+    # In plan-only (dry-run) mode we write the planned per-owner Issue
+    # bodies to ``issues-planned/`` instead of ``issues/`` so the nightly
+    # workflow's ``gh issue create`` loop (which globs ``issues/*.md``)
+    # finds nothing and is effectively a no-op. Reviewers can grep the
+    # ``issues-planned/`` directory before flipping the flag off.
+    issues_dirname = "issues-planned" if plan_only else "issues"
+    issues_dir = out_dir / issues_dirname
     issues_dir.mkdir(exist_ok=True)
 
     findings: list[Finding] = []
@@ -523,13 +538,18 @@ def run(hidden_waste_csv: Path | None,
             by_owner[f.owner or "_unowned"].append(f)
     for owner, items in by_owner.items():
         write_owner_issue(issues_dir / f"{slug(owner)}-{date}.md",
-                          owner if owner != "_unowned" else "Unowned", items)
+                          owner if owner != "_unowned" else "Unowned", items,
+                          plan_only=plan_only)
 
     print(f"[enricher] Done.")
     print(f"  - {csv_path}")
     print(f"  - {md_path}")
     print(f"  - {html_path}")
-    print(f"  - {issues_dir}/  ({len(by_owner)} per-owner issue templates)")
+    label = "planned (dry-run)" if plan_only else "per-owner issue templates"
+    print(f"  - {issues_dir}/  ({len(by_owner)} {label})")
+    if plan_only:
+        print("[enricher] PLAN-ONLY: no GitHub Issues will be opened. "
+              "Review the bodies above, then re-run without --plan-only.")
     high = sum(1 for f in findings if f.confidence == "HIGH")
     med  = sum(1 for f in findings if f.confidence == "MED")
     low  = sum(1 for f in findings if f.confidence == "LOW")
@@ -543,10 +563,23 @@ def main():
     ap.add_argument("--hidden-waste-csv", type=Path)
     ap.add_argument("--rightsizing-csv", type=Path)
     ap.add_argument("--out-dir", type=Path, required=True)
+    ap.add_argument(
+        "--plan-only",
+        action="store_true",
+        help=(
+            "Dry-run: write planned per-owner Issue bodies to "
+            "out-dir/issues-planned/ instead of issues/, and print a "
+            "PLAN-ONLY banner. No GitHub Issues are opened — the nightly "
+            "workflow's gh issue create step globs issues/*.md and finds "
+            "nothing. Reviewers can grep issues-planned/ before flipping "
+            "the flag off."
+        ),
+    )
     args = ap.parse_args()
     if not args.hidden_waste_csv and not args.rightsizing_csv:
         ap.error("Provide at least one of --hidden-waste-csv / --rightsizing-csv.")
-    run(args.hidden_waste_csv, args.rightsizing_csv, args.out_dir)
+    run(args.hidden_waste_csv, args.rightsizing_csv, args.out_dir,
+        plan_only=args.plan_only)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements issue #21 — adds a `--plan-only` dry-run flag to `context-enricher` so reviewers can preview the planned per-owner Issue bodies *before* the nightly workflow opens hundreds of GitHub Issues.

## What's new

- **Engine** (`tools/context-enricher/context_enricher.py`):
  - New `--plan-only` CLI flag, threaded through `run()` as a kwarg.
  - When set, per-owner bodies are written to `<out-dir>/issues-planned/` instead of `<out-dir>/issues/`.
  - Each planned body carries a `> ⚠️ DRY-RUN — --plan-only mode.` banner so operators can't accidentally treat a planned body as a published one.
  - Final summary prints `[enricher] PLAN-ONLY: no GitHub Issues will be opened. …`.

- **Workflow** (`automation/finops-nightly.yml`):
  - New `plan_only` `workflow_dispatch` boolean input, **default `true`** — recommended posture for the first run on a new tenant per the issue's acceptance criteria.
  - Phase 4 step appends `--plan-only` to the engine command when the input is true.
  - The `Open / update per-owner issues` step is gated with `if: success() && inputs.plan_only != true`.
  - A new `Plan-only summary` step prints a `::notice::` and lists the planned bodies for visibility in the run summary.

## Routing posture (why it works without any further wiring)

The workflow's `gh issue create` loop globs `Enriched/issues/*.md`. A plan-only engine run writes to `issues-planned/` and never populates that path, so the loop is a deliberate no-op even if a future workflow edit forgets to gate the step. Defence in depth.

## Tests

5 new tests in `tests/test_context_enricher_plan_only.py` (full suite now **51 passing**):

- `issues-planned/` is created and `issues/` is left empty in plan-only mode.
- All planned bodies carry the `DRY-RUN` / `--plan-only` banner.
- Default mode still writes to `issues/` and never creates `issues-planned/` or the banner.
- `[enricher] PLAN-ONLY` summary line is printed.
- `--plan-only` is wired through to argparse (`--help` documents it).

## Docs

- `tools/context-enricher/README.md`: new **Dry-run / plan-only mode** section with the recommended `workflow_dispatch` posture; `Outputs` section documents the `issues-planned/` path.
- `ROADMAP.md`: strikethrough on the 🛡 🟢 `--plan-only` bullet, linking #21.
- `CHANGELOG.md`: `[Unreleased]` `### Added` entry.

No version bump — additive, behaviour-preserving by default.

Closes #21.
