### PR TITLE
feat(currency): auto-detect tenant billing currency across engines (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ as detailed in [`VERSIONING.md`](./VERSIONING.md).
 
 ### Added
 
+- **Currency auto-detect across all engines (issue [#14](https://github.com/prbeegala/FinOpsEngine/issues/14)).**
+  `hidden-waste`, `ri-coverage`, and `context-enricher` now call
+  `az billing account list` once at startup, read the tenant's billing
+  currency, and render headlines / tables / per-owner Issue bodies in
+  the matching glyph (USD `$`, EUR `€`, SEK `kr`, JPY `¥`, etc. — 18
+  ISO-4217 codes mapped, unknown codes fall back to the raw ISO).
+  A new `--currency-symbol` flag overrides detection (accepts any
+  string, including multi-character glyphs like `kr` / `A$`). When
+  detection fails (no Billing Reader, offline run, malformed
+  response), engines silently fall back to the historical `£` default
+  and print a one-line provenance message at startup. Numeric values
+  are unchanged — Cost Management already returns amounts in the
+  tenant billing currency. Shared helper lives at
+  `tools/finops_currency.py` (covered by 18 unit tests).
+  `rightsizing-peak` was unaffected (it doesn't print money).
+
+### Changed
+
+- **`ri-coverage`: `--refund-buffer-gbp` renamed to `--refund-buffer`.**
+  The old GBP-suffixed flag remains as a deprecated alias for one
+  release so existing automation (`automation/finops-nightly.yml`,
+  custom CI) keeps working — invoking it prints a deprecation warning
+  to stderr but otherwise behaves identically. Update your wrappers
+  before the v0.3.0 release, when the alias will be removed.
+
+### Added
+
 - **`context-enricher`: `--plan-only` dry-run mode (issue [#21](https://github.com/prbeegala/FinOpsEngine/issues/21)).**
   When the flag is set, per-owner Issue bodies are written to
   `<out-dir>/issues-planned/` instead of `<out-dir>/issues/` and each

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ python tools/hidden-waste/hidden_waste.py `
 python tools/ri-coverage/ri_coverage.py `
   --all-subs `
   --months 3 `
-  --refund-buffer-gbp 5000 `
+  --refund-buffer 5000 `
   --out-dir ./out/ri-coverage
 
 # 3. Join everything into per-owner remediation queues

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,16 +72,12 @@ Refinements to the existing four engines.
 - 🟢 **context-enricher: tag + YAML routing fallback** — today owners are
   resolved from `CODEOWNERS`. Add support for `owner=` / `costcenter=`
   Azure Tags and a YAML override file for orgs without `CODEOWNERS`.
-- 🟢 **Currency auto-detect via `az billing account list`** — today the
-  `£` glyph is hard-coded as a display label across all four engines,
-  and operators on USD / EUR / SEK / etc. tenants have to search-replace
-  the symbol in source. Read the billing account currency once at
-  startup, parameterise the display glyph (and the
-  `--refund-buffer-gbp` flag → `--refund-buffer`), and surface the
-  detected currency in the report headers. The numeric values are
-  already in the tenant's billing currency — this just stops the label
-  lying. Also closes the FAQ entry that points to the search-replace
-  workaround.
+- ~~🟢 **Currency auto-detect via `az billing account list`**~~ — shipped
+  in [#14](https://github.com/prbeegala/FinOpsEngine/issues/14). Engines
+  now read the billing currency once at startup and accept
+  `--currency-symbol` to override; `--refund-buffer-gbp` was renamed to
+  `--refund-buffer` (the GBP-suffixed alias still works for one
+  release).
 
 ## Issue lifecycle & dedupe 🛡
 

--- a/automation/finops-nightly.yml
+++ b/automation/finops-nightly.yml
@@ -94,7 +94,7 @@ jobs:
           python -u ri_coverage.py \
             --subs "$SUBS" \
             --months 3 \
-            --refund-buffer-gbp "$REFUND_BUFFER" \
+            --refund-buffer "$REFUND_BUFFER" \
             --out-dir "$OUT_BASE/RICoverage"
         continue-on-error: true
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -55,18 +55,32 @@ mis-tagged charges) is on the [roadmap](../ROADMAP.md).
 
 ### Why £? Can I make it $?
 
-The £ glyph is a display-only label in the engines. The numeric values come
-straight from your Azure billing currency. To change the display:
+By default, every engine calls `az billing account list` once at startup
+and renders amounts in the tenant's billing currency (USD, EUR, SEK,
+etc.). The numeric values themselves come straight from Azure Cost
+Management — only the glyph is local. If detection fails (no Billing
+Reader, offline run, multi-currency setup), the engine falls back to
+`£` and prints a one-line provenance message so you can spot it.
+
+To force a specific glyph (e.g. when you want consistent reports
+across multiple tenants, or you're billed in a currency Azure doesn't
+expose to the CLI):
 
 ```pwsh
-# From the repo root, swap £ for $ in all engine sources:
-(Get-ChildItem tools -Recurse -Include *.py).FullName | ForEach-Object {
-  (Get-Content $_ -Raw) -replace '£','$' | Set-Content $_
-}
+python tools\hidden-waste\hidden_waste.py    --currency-symbol '$' ...
+python tools\ri-coverage\ri_coverage.py      --currency-symbol '€' ...
+python tools\context-enricher\context_enricher.py --currency-symbol 'kr' ...
 ```
 
-A future release will read the billing account's currency via
-`az billing account list` and parameterise.
+The flag accepts any string, so multi-character glyphs like `kr`,
+`A$`, `NT$` work too. `rightsizing-peak` doesn't print money (it
+emits verdicts) so it doesn't take the flag.
+
+> **Note**: the engines do not perform FX conversion. Cost Management
+> already returns amounts in the tenant billing currency; we only
+> change the display glyph. If your tenant is genuinely multi-currency,
+> talk to your Microsoft account team about consolidating onto a
+> single MCA billing account first.
 
 ### Will the engines delete anything?
 

--- a/tests/test_finops_currency.py
+++ b/tests/test_finops_currency.py
@@ -1,0 +1,155 @@
+"""Unit tests for tools/finops_currency.py.
+
+The helper is the only piece of the currency feature that is exercised
+during real engine runs (engines themselves are tested via run() which
+bypasses detection and inherits the £ default). These tests therefore
+focus on the resolution order, the three Azure CLI response shapes the
+helper claims to support, and the never-raises contract.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+import finops_currency  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+class FakeCompleted:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _patch_az(monkeypatch, response: FakeCompleted | Exception | None):
+    """Replace subprocess.run inside finops_currency with a sentinel.
+
+    Pass ``None`` to assert that subprocess.run is never called.
+    """
+    calls: list[Any] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if isinstance(response, Exception):
+            raise response
+        if response is None:
+            raise AssertionError(
+                "subprocess.run should not be called when override is set"
+            )
+        return response
+
+    monkeypatch.setattr(finops_currency.subprocess, "run", fake_run)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# detect_currency — override path
+# ---------------------------------------------------------------------------
+
+def test_override_short_circuits_subprocess(monkeypatch):
+    calls = _patch_az(monkeypatch, None)
+    sym, iso, src = finops_currency.detect_currency(override="$")
+    assert (sym, iso, src) == ("$", "", "override")
+    assert calls == []
+
+
+def test_override_passed_through_verbatim(monkeypatch):
+    _patch_az(monkeypatch, None)
+    # Multi-char glyphs (e.g. 'kr', 'A$') must be returned untouched.
+    sym, iso, src = finops_currency.detect_currency(override="kr")
+    assert sym == "kr"
+    assert src == "override"
+
+
+# ---------------------------------------------------------------------------
+# detect_currency — billing-account path (3 response shapes)
+# ---------------------------------------------------------------------------
+
+def test_mca_shape_resolves_currency(monkeypatch):
+    payload = json.dumps([
+        {"soldToInfo": {"billingCurrency": "USD"}},
+    ])
+    _patch_az(monkeypatch, FakeCompleted(0, payload))
+    sym, iso, src = finops_currency.detect_currency()
+    assert (sym, iso, src) == ("$", "USD", "billing-account")
+
+
+def test_ea_shape_resolves_currency(monkeypatch):
+    payload = json.dumps([
+        {"properties": {"currency": "EUR"}},
+    ])
+    _patch_az(monkeypatch, FakeCompleted(0, payload))
+    sym, iso, src = finops_currency.detect_currency()
+    assert (sym, iso, src) == ("€", "EUR", "billing-account")
+
+
+def test_top_level_fallback_shape(monkeypatch):
+    payload = json.dumps([{"currency": "SEK"}])
+    _patch_az(monkeypatch, FakeCompleted(0, payload))
+    sym, iso, src = finops_currency.detect_currency()
+    assert (sym, iso, src) == ("kr", "SEK", "billing-account")
+
+
+def test_unknown_iso_falls_back_to_iso_code(monkeypatch):
+    payload = json.dumps([{"properties": {"currency": "XYZ"}}])
+    _patch_az(monkeypatch, FakeCompleted(0, payload))
+    sym, iso, src = finops_currency.detect_currency()
+    # XYZ isn't in CURRENCY_SYMBOLS — symbol falls back to the raw ISO.
+    assert (sym, iso, src) == ("XYZ", "XYZ", "billing-account")
+
+
+# ---------------------------------------------------------------------------
+# detect_currency — default / failure paths (the never-raises contract)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("response", [
+    FakeCompleted(1, "", "ERROR: not logged in"),    # az returned non-zero
+    FakeCompleted(0, ""),                             # empty stdout
+    FakeCompleted(0, "[]"),                           # no billing accounts
+    FakeCompleted(0, "{not valid json"),              # malformed JSON
+    FakeCompleted(0, json.dumps({"not": "a list"})),  # wrong root type
+    FakeCompleted(0, json.dumps([{"soldToInfo": {}}])),  # no currency field
+    OSError("az not on PATH"),                        # subprocess raised
+    subprocess.TimeoutExpired(cmd="az", timeout=20),  # billing API hung
+])
+def test_detection_failures_fall_back_to_default(monkeypatch, response):
+    _patch_az(monkeypatch, response)
+    sym, iso, src = finops_currency.detect_currency()
+    assert (sym, iso, src) == ("£", "GBP", "default")
+
+
+def test_detection_skips_non_dict_entries(monkeypatch):
+    payload = json.dumps([None, "string", 42, {"properties": {"currency": "JPY"}}])
+    _patch_az(monkeypatch, FakeCompleted(0, payload))
+    sym, iso, src = finops_currency.detect_currency()
+    assert (sym, iso, src) == ("¥", "JPY", "billing-account")
+
+
+# ---------------------------------------------------------------------------
+# format_amount + CURRENCY_SYMBOLS sanity checks
+# ---------------------------------------------------------------------------
+
+def test_format_amount_default_zero_dp():
+    assert finops_currency.format_amount("£", 1234.56) == "£1,235"
+
+
+def test_format_amount_with_dp():
+    assert finops_currency.format_amount("$", 1234.5, dp=2) == "$1,234.50"
+
+
+def test_currency_symbols_covers_major_isos():
+    for iso in ("GBP", "USD", "EUR", "AUD", "CAD", "JPY", "INR", "SEK"):
+        assert iso in finops_currency.CURRENCY_SYMBOLS, iso
+    assert finops_currency.CURRENCY_SYMBOLS["GBP"] == "£"
+    assert finops_currency.CURRENCY_SYMBOLS["USD"] == "$"
+    assert finops_currency.CURRENCY_SYMBOLS["EUR"] == "€"

--- a/tools/context-enricher/README.md
+++ b/tools/context-enricher/README.md
@@ -76,6 +76,17 @@ without the flag (or with `plan_only=false` from `workflow_dispatch`).
 Each body carries a `> ⚠️ DRY-RUN — --plan-only mode.` banner so
 operators can't accidentally treat a planned body as a published one.
 
+### Currency display
+
+By default the enricher renders amounts in the tenant's billing
+currency, auto-detected via `az billing account list` once at startup.
+Pass `--currency-symbol '$'` (or `'€'`, `'kr'`, etc.) to override —
+useful when running across tenants with mixed billing accounts or when
+the CLI doesn't return a currency. Detection failures fall back to
+`£` and print a one-line provenance message; numeric values are
+unchanged because Cost Management already returns amounts in the
+tenant's billing currency.
+
 ## Outputs
 
 - `enriched-<date>.csv` — every finding with owner / criticality / env /

--- a/tools/context-enricher/context_enricher.py
+++ b/tools/context-enricher/context_enricher.py
@@ -50,6 +50,14 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from html_sink import write_html, write_index  # noqa: E402
+from finops_currency import detect_currency  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Display currency (overridden in main() from CLI / billing-account auto-detect).
+# Defaults to GBP so existing fixtures / sample snapshots keep passing.
+# ---------------------------------------------------------------------------
+CURRENCY: str = "£"
+CURRENCY_ISO: str = "GBP"
 
 # ---------------------------------------------------------------------------
 # Tag conventions — case-insensitive lookup, first match wins.
@@ -270,7 +278,8 @@ def classify(f: Finding) -> None:
     if has_owner and (has_crit or has_env) and f.monthly_gbp >= HIGH_GBP_FLOOR:
         f.confidence = "HIGH"
         f.rationale = ("Owner + criticality/environment context present and "
-                       f"value (£{f.monthly_gbp:.0f}/mo) clears the auto-issue floor.")
+                       f"value ({CURRENCY}{f.monthly_gbp:.0f}/mo) clears the "
+                       "auto-issue floor.")
     elif (has_owner or has_crit) and f.monthly_gbp >= MED_GBP_FLOOR:
         f.confidence = "MED"
         bits = []
@@ -284,8 +293,8 @@ def classify(f: Finding) -> None:
             f.rationale = ("Untagged — belongs in the tagging-debt backlog, "
                            "not the remediation queue.")
         else:
-            f.rationale = (f"Below £{MED_GBP_FLOOR:.0f}/mo threshold — bulk-handle "
-                           "in next quarterly clean-up.")
+            f.rationale = (f"Below {CURRENCY}{MED_GBP_FLOOR:.0f}/mo threshold "
+                           "— bulk-handle in next quarterly clean-up.")
 
 
 # ---------------------------------------------------------------------------
@@ -334,49 +343,49 @@ def write_summary_md(path: Path, findings: list[Finding]) -> None:
     L.append("")
     L.append("## Confidence breakdown")
     L.append("")
-    L.append("| Band | Count | Monthly £ | Routing |")
+    L.append("| Band | Count | Monthly cost | Routing |")
     L.append("|---|---:|---:|---|")
     L.append(f"| HIGH (auto-issue ready) | {len(by_conf['HIGH'])} | "
-             f"£{auto_monthly:,.0f} | Domain owner GitHub Issue |")
+             f"{CURRENCY}{auto_monthly:,.0f} | Domain owner GitHub Issue |")
     L.append(f"| MED  (review first) | {len(by_conf['MED'])} | "
-             f"£{review_monthly:,.0f} | FinOps weekly triage |")
-    L.append(f"| LOW  (tagging debt / sub-£25) | {len(by_conf['LOW'])} | "
-             f"£{debt_monthly:,.0f} | Platform-team backlog |")
-    L.append(f"| **Total** | **{len(findings)}** | **£{total_monthly:,.0f}** | |")
+             f"{CURRENCY}{review_monthly:,.0f} | FinOps weekly triage |")
+    L.append(f"| LOW  (tagging debt / sub-{CURRENCY}25) | {len(by_conf['LOW'])} | "
+             f"{CURRENCY}{debt_monthly:,.0f} | Platform-team backlog |")
+    L.append(f"| **Total** | **{len(findings)}** | **{CURRENCY}{total_monthly:,.0f}** | |")
     L.append("")
     L.append("## Auto-issue queue by owner")
     L.append("")
     if not by_owner:
         L.append("_No HIGH/MED findings._")
     else:
-        L.append("| Owner | Count | Monthly £ | Bundle |")
+        L.append("| Owner | Count | Monthly cost | Bundle |")
         L.append("|---|---:|---:|---|")
         for owner in sorted(by_owner.keys(),
                             key=lambda k: -sum(f.monthly_gbp for f in by_owner[k])):
             items = by_owner[owner]
             mo = sum(f.monthly_gbp for f in items)
-            L.append(f"| {owner} | {len(items)} | £{mo:,.0f} | "
+            L.append(f"| {owner} | {len(items)} | {CURRENCY}{mo:,.0f} | "
                      f"`issues/{slug(owner)}.md` |")
     L.append("")
     L.append("## Top 25 individual findings")
     L.append("")
-    L.append("| Owner | Sub | Resource | Category | Confidence | £/mo |")
+    L.append("| Owner | Sub | Resource | Category | Confidence | Cost/mo |")
     L.append("|---|---|---|---|---|---:|")
     for f in sorted(findings, key=lambda x: -x.monthly_gbp)[:25]:
         L.append(f"| {f.owner or '_(untagged)_'} | {f.sub_name} | {f.name} | "
-                 f"{f.category} | {f.confidence} | £{f.monthly_gbp:,.0f} |")
+                 f"{f.category} | {f.confidence} | {CURRENCY}{f.monthly_gbp:,.0f} |")
     L.append("")
-    L.append("## Tagging debt (top 10 LOW by £)")
+    L.append("## Tagging debt (top 10 LOW by spend)")
     L.append("")
     debt_top = sorted(by_conf["LOW"], key=lambda x: -x.monthly_gbp)[:10]
     if not debt_top:
         L.append("_None — every finding has at least owner or criticality._")
     else:
-        L.append("| Sub | Resource | Category | £/mo |")
+        L.append("| Sub | Resource | Category | Cost/mo |")
         L.append("|---|---|---|---:|")
         for f in debt_top:
             L.append(f"| {f.sub_name} | {f.name} | {f.category} | "
-                     f"£{f.monthly_gbp:,.0f} |")
+                     f"{CURRENCY}{f.monthly_gbp:,.0f} |")
     L.append("")
     L.append("---")
     L.append("")
@@ -400,8 +409,8 @@ def write_owner_issue(path: Path, owner: str, items: list[Finding],
         L.append("")
     L.append(f"## FinOps remediation queue — {owner or 'Unowned'}")
     L.append("")
-    L.append(f"**{len(items)} findings · ~£{monthly:,.0f} / month "
-             f"(£{annual:,.0f} / yr) recoverable.**")
+    L.append(f"**{len(items)} findings · ~{CURRENCY}{monthly:,.0f} / month "
+             f"({CURRENCY}{annual:,.0f} / yr) recoverable.**")
     L.append("")
     L.append("> Generated by the FinOps Engine automation. Each row links back "
              "to the engine that surfaced it; deletion / rightsizing remains "
@@ -409,12 +418,12 @@ def write_owner_issue(path: Path, owner: str, items: list[Finding],
              "`reject` per row to update the tracker.")
     L.append("")
     L.append("| # | Resource | Category | Confidence | Criticality | "
-             "Environment | £/mo |")
+             "Environment | Cost/mo |")
     L.append("|---:|---|---|---|---|---|---:|")
     for i, f in enumerate(items, 1):
         L.append(f"| {i} | `{f.name}` ({f.sub_name}/{f.resource_group}) | "
                  f"{f.category} | {f.confidence} | {f.criticality or '—'} | "
-                 f"{f.environment or '—'} | £{f.monthly_gbp:,.0f} |")
+                 f"{f.environment or '—'} | {CURRENCY}{f.monthly_gbp:,.0f} |")
     L.append("")
     L.append("### Source data")
     L.append("")
@@ -433,7 +442,7 @@ def write_owner_issue(path: Path, owner: str, items: list[Finding],
     L.append("")
     L.append("### Suggested next step")
     L.append("")
-    L.append("1. Eyeball the top 3 by £ — these are 80% of the spend.")
+    L.append("1. Eyeball the top 3 by spend — these are 80% of the spend.")
     L.append("2. For HIGH-confidence rows, raise a change ticket against the "
              "named resource group.")
     L.append("3. For MED rows, confirm criticality / environment with the "
@@ -554,7 +563,7 @@ def run(hidden_waste_csv: Path | None,
     med  = sum(1 for f in findings if f.confidence == "MED")
     low  = sum(1 for f in findings if f.confidence == "LOW")
     high_gbp = sum(f.monthly_gbp for f in findings if f.confidence == "HIGH")
-    print(f"[enricher] Confidence: HIGH={high} (£{high_gbp:,.0f}/mo), "
+    print(f"[enricher] Confidence: HIGH={high} ({CURRENCY}{high_gbp:,.0f}/mo), "
           f"MED={med}, LOW={low}.")
 
 
@@ -575,9 +584,28 @@ def main():
             "the flag off."
         ),
     )
+    ap.add_argument(
+        "--currency-symbol", type=str, default=None,
+        help="Override the auto-detected display currency glyph (e.g. "
+             "'$', '€', 'kr'). When omitted, the engine calls "
+             "`az billing account list` once to read the tenant's "
+             "billing currency and falls back to '£' on any failure.",
+    )
     args = ap.parse_args()
     if not args.hidden_waste_csv and not args.rightsizing_csv:
         ap.error("Provide at least one of --hidden-waste-csv / --rightsizing-csv.")
+    global CURRENCY, CURRENCY_ISO
+    sym, iso, source = detect_currency(args.currency_symbol)
+    CURRENCY = sym
+    CURRENCY_ISO = iso or CURRENCY_ISO
+    src_label = {
+        "override": "from --currency-symbol",
+        "billing-account": "from `az billing account list`",
+        "default": "default — set --currency-symbol or grant Billing "
+                   "Reader to silence this",
+    }.get(source, source)
+    print(f"[enricher] Display currency: {CURRENCY} "
+          f"({CURRENCY_ISO or '?'}) — {src_label}")
     run(args.hidden_waste_csv, args.rightsizing_csv, args.out_dir,
         plan_only=args.plan_only)
 

--- a/tools/finops_currency.py
+++ b/tools/finops_currency.py
@@ -1,0 +1,167 @@
+"""finops_currency.py — runtime currency detection for the FinOps Engine.
+
+Part of the FinOps Engine shared utilities. No third-party dependencies —
+uses the Python standard library and the Azure CLI only.
+
+The Cost Management ``/query`` API already returns numbers in the
+**tenant's billing currency** (a single tenant has exactly one billing
+currency at any point in time). We therefore never need to convert
+amounts; we only need to know which symbol to render so report headers,
+shortlists, and per-owner Issue bodies stop hard-coding ``£`` for tenants
+that are billed in USD / EUR / SEK / etc.
+
+Public API
+----------
+    CURRENCY_SYMBOLS
+        ``dict[str, str]`` mapping ISO-4217 codes to the conventional
+        display glyph (defaults fall back to the raw code).
+
+    detect_currency(override=None) -> tuple[str, str, str]
+        Returns ``(symbol, iso_code, source)`` where ``source`` is one of
+        ``"override"`` / ``"billing-account"`` / ``"default"``. The
+        function never raises — failures fall back to ``("£", "GBP",
+        "default")`` so existing snapshots / fixtures continue to pass.
+
+    format_amount(symbol, value, dp=0) -> str
+        Convenience formatter that renders ``"£1,234"`` / ``"$1,234.56"``
+        with thousands separators. Engines that maintain their own
+        bespoke formatters (e.g. ``hidden-waste`` switches between
+        ``£0.00`` and ``£1,234`` depending on magnitude) are not forced
+        to use this — the symbol is the contract, not the formatter.
+
+The detection call is **best-effort, single-shot, and silent on failure**
+— it must not block engine startup, and any stderr from ``az`` is
+swallowed. Operators on tenants where the API response is unhelpful
+should set ``--currency-symbol`` explicitly.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Tuple
+
+# ISO-4217 → conventional display glyph. Currencies not in this map fall
+# back to the ISO code itself (e.g. ``"NOK"`` rather than guessing
+# ``"kr"``). Order is alphabetical by ISO code for diffability.
+CURRENCY_SYMBOLS: dict[str, str] = {
+    "AUD": "A$",
+    "CAD": "C$",
+    "CHF": "CHF",
+    "CNY": "¥",
+    "DKK": "kr",
+    "EUR": "€",
+    "GBP": "£",
+    "HKD": "HK$",
+    "INR": "₹",
+    "JPY": "¥",
+    "KRW": "₩",
+    "NOK": "kr",
+    "NZD": "NZ$",
+    "SEK": "kr",
+    "SGD": "S$",
+    "TWD": "NT$",
+    "USD": "$",
+    "ZAR": "R",
+}
+
+DEFAULT_SYMBOL = "£"
+DEFAULT_ISO = "GBP"
+
+
+def _symbol_for(iso: str) -> str:
+    """Return the display glyph for an ISO code, or the code itself."""
+    iso = (iso or "").strip().upper()
+    if not iso:
+        return DEFAULT_SYMBOL
+    return CURRENCY_SYMBOLS.get(iso, iso)
+
+
+def detect_currency(override: str | None = None) -> Tuple[str, str, str]:
+    """Resolve the display currency for an engine run.
+
+    Resolution order:
+
+    1. ``override`` — if a non-empty string is supplied (typically from a
+       ``--currency-symbol`` CLI flag), it wins. Returned as-is; no
+       lookup, no validation.
+    2. ``az billing account list`` — first non-empty
+       ``soldToInfo.billingCurrency`` (Microsoft Customer Agreement
+       shape) or top-level ``properties.currency`` (Enterprise
+       Agreement shape). Mapped via :data:`CURRENCY_SYMBOLS`.
+    3. Default ``("£", "GBP", "default")`` — preserves existing
+       behaviour and keeps every snapshot fixture green.
+
+    The function **never raises**. Any subprocess failure, JSON parse
+    error, or unexpected response shape falls through to the default.
+
+    Returns
+    -------
+    (symbol, iso_code, source)
+        ``source`` is one of ``"override"``, ``"billing-account"``,
+        ``"default"`` — used by engines to print a one-line provenance
+        message at startup.
+    """
+    if override:
+        return (override, "", "override")
+
+    iso = _query_billing_currency()
+    if iso:
+        return (_symbol_for(iso), iso, "billing-account")
+
+    return (DEFAULT_SYMBOL, DEFAULT_ISO, "default")
+
+
+def _query_billing_currency() -> str:
+    """Best-effort ``az billing account list`` → ISO code, ``""`` on any failure."""
+    try:
+        proc = subprocess.run(
+            ["az", "billing", "account", "list", "--only-show-errors", "-o", "json"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return ""
+
+    try:
+        accounts = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return ""
+
+    if not isinstance(accounts, list):
+        return ""
+
+    for acc in accounts:
+        if not isinstance(acc, dict):
+            continue
+        # Microsoft Customer Agreement: soldToInfo.billingCurrency.
+        sold = acc.get("soldToInfo") or {}
+        if isinstance(sold, dict):
+            cur = sold.get("billingCurrency") or sold.get("currency")
+            if cur:
+                return str(cur)
+        # Enterprise Agreement / legacy: properties.currency.
+        props = acc.get("properties") or {}
+        if isinstance(props, dict):
+            cur = props.get("currency") or props.get("billingCurrency")
+            if cur:
+                return str(cur)
+        # Top-level fallback (some tenants surface it here).
+        cur = acc.get("currency") or acc.get("billingCurrency")
+        if cur:
+            return str(cur)
+    return ""
+
+
+def format_amount(symbol: str, value: float, dp: int = 0) -> str:
+    """Render ``value`` with thousands separators prefixed by ``symbol``.
+
+    Engines may keep using f-strings like ``f"{CURRENCY}{x:,.0f}"``;
+    this helper exists for the few call sites where the dp count is
+    conditional on magnitude.
+    """
+    return f"{symbol}{value:,.{dp}f}"

--- a/tools/hidden-waste/README.md
+++ b/tools/hidden-waste/README.md
@@ -91,6 +91,7 @@ python hidden_waste.py `
 | `--ca-idle-requests-max <n>` | Container Apps: total `Requests` ≤ this counts as idle. Default `0`. |
 | `--ca-idle-days <n>` | Container Apps observation window in days. Default `14`. |
 | `--skip-metrics` | Skip Azure Monitor calls. PaaS rightsizing candidates are dropped (they can't be qualified without metrics); storage detectors fall back to their own posture. |
+| `--currency-symbol <glyph>` | Override the auto-detected display currency (e.g. `$`, `€`, `kr`). Defaults to whatever `az billing account list` reports for the tenant, falling back to `£`. Numeric values are unchanged — Cost Management already returns amounts in the tenant's billing currency. |
 
 ## Outputs
 

--- a/tools/hidden-waste/hidden_waste.py
+++ b/tools/hidden-waste/hidden_waste.py
@@ -65,6 +65,14 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from html_sink import write_html, write_index  # noqa: E402
+from finops_currency import detect_currency  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Display currency (overridden in main() from CLI / billing-account auto-detect).
+# Defaults to GBP so existing fixtures / sample snapshots keep passing.
+# ---------------------------------------------------------------------------
+CURRENCY: str = "£"
+CURRENCY_ISO: str = "GBP"
 
 # ---------------------------------------------------------------------------
 # Subprocess helpers
@@ -883,8 +891,8 @@ def annotate_cost(finding: Finding, cost_map: dict[str, float],
 
 def gbp(x: float) -> str:
     if abs(x) >= 1000:
-        return f"£{x:,.0f}"
-    return f"£{x:,.2f}"
+        return f"{CURRENCY}{x:,.0f}"
+    return f"{CURRENCY}{x:,.2f}"
 
 
 def write_csv(path: Path, findings: list[Finding]) -> None:
@@ -919,13 +927,13 @@ def write_md(path: Path, findings: list[Finding], sub_count: int) -> None:
         "## Headline",
         "",
         f"- Total flagged resources: **{total_count:,}**",
-        f"- Estimated monthly £ recoverable (deletion or rightsizing): "
+        f"- Estimated monthly cost recoverable (deletion or rightsizing): "
         f"**{gbp(total_monthly)}**",
         f"- Annualised: **{gbp(total_monthly * 12)}**",
         "",
         "## By category",
         "",
-        "| Category | Count | Monthly £ | Annualised £ |",
+        "| Category | Count | Monthly cost | Annualised |",
         "|---|---:|---:|---:|",
     ]
     for cat in QUERIES.keys():
@@ -950,7 +958,7 @@ def write_md(path: Path, findings: list[Finding], sub_count: int) -> None:
         "",
         "## Top 25 individual offenders (across all categories)",
         "",
-        "| Sub | RG | Resource | Category | Monthly £ | Source |",
+        "| Sub | RG | Resource | Category | Monthly cost | Source |",
         "|---|---|---|---|---:|---|",
     ]
     for f in sorted(findings, key=lambda f: -f.monthly_gbp)[:25]:
@@ -962,7 +970,7 @@ def write_md(path: Path, findings: list[Finding], sub_count: int) -> None:
 
     lines += [
         "",
-        "## Recommended Azure Policy guardrails (top 3 by £)",
+        "## Recommended Azure Policy guardrails (top 3 by spend)",
         "",
         "Starter-pack JSON for the top 3 waste classes is in `policy/`. These "
         "are *audit-mode* policies — they flag new offenders without "
@@ -978,7 +986,7 @@ def write_md(path: Path, findings: list[Finding], sub_count: int) -> None:
         "",
         "## Cost-source notes",
         "",
-        "- `cost_mgmt` — actual £ from last 30 days of Cost Management.",
+        "- `cost_mgmt` — actual cost from last 30 days of Cost Management.",
         "- `estimate` — list-price estimate (used when Cost Management "
         "  has no data for that resource ID, e.g. never-attached disks).",
         "- `unknown` — no cost attribution available; verify manually.",
@@ -1402,7 +1410,7 @@ def run(subs: list[str], out_dir: Path,
     print(f"  - {tool_dir / 'policy'}/  (audit-mode policies for all "
           f"12 classes)")
     print(f"[engine] Total flagged: {len(raw_findings):,} resources, "
-          f"~£{total_monthly:,.0f}/mo (~£{total_monthly * 12:,.0f}/yr).")
+          f"~{gbp(total_monthly)}/mo (~{gbp(total_monthly * 12)}/yr).")
 
 
 def _resolve_subs(args) -> list[str]:
@@ -1481,7 +1489,26 @@ def main():
                          "candidates are dropped because they can't be "
                          "qualified without metrics. Storage refinement "
                          "may still query Azure Monitor metrics.")
+    ap.add_argument(
+        "--currency-symbol", type=str, default=None,
+        help="Override the auto-detected display currency glyph (e.g. "
+             "'$', '€', 'kr'). When omitted, the engine calls "
+             "`az billing account list` once to read the tenant's "
+             "billing currency and falls back to '£' on any failure.",
+    )
     args = ap.parse_args()
+    global CURRENCY, CURRENCY_ISO
+    sym, iso, source = detect_currency(args.currency_symbol)
+    CURRENCY = sym
+    CURRENCY_ISO = iso or CURRENCY_ISO
+    src_label = {
+        "override": "from --currency-symbol",
+        "billing-account": "from `az billing account list`",
+        "default": "default — set --currency-symbol or grant Billing "
+                   "Reader to silence this",
+    }.get(source, source)
+    print(f"[engine] Display currency: {CURRENCY} "
+          f"({CURRENCY_ISO or '?'}) — {src_label}")
     subs = _resolve_subs(args)
     run(subs, Path(args.out_dir),
         asp_idle_days=args.asp_idle_days,

--- a/tools/ri-coverage/README.md
+++ b/tools/ri-coverage/README.md
@@ -31,13 +31,13 @@ Pick a scope. The engine requires **either** `--subs` (explicit list) **or**
 python ri_coverage.py `
   --subs "<id1>,<id2>,..." `
   --months 3 `
-  --refund-buffer-gbp 5000 `
+  --refund-buffer 5000 `
   --out-dir ./out/ri-coverage
 
 # Every enabled subscription in the current tenant
 python ri_coverage.py `
   --all-subs `
-  --refund-buffer-gbp 5000 `
+  --refund-buffer 5000 `
   --out-dir ./out/ri-coverage
 ```
 
@@ -53,6 +53,7 @@ python ri_coverage.py `
 | `--exclude-subs <a,b>` | When using `--all-subs`, skip these IDs/names. |
 | `--tenant <guid>` | Limit `--all-subs` to a single tenant. |
 | `--include-disabled` | Include subs whose state is not Enabled. |
+| `--currency-symbol <glyph>` | Override the auto-detected display currency (e.g. `$`, `€`, `kr`). Defaults to whatever `az billing account list` reports for the tenant, falling back to `£`. Affects display only — the underlying numbers come straight from Cost Management. |
 
 ## Outputs
 
@@ -63,25 +64,31 @@ python ri_coverage.py `
 
 ## The cancellation-exposure buffer
 
-The most important argument is `--refund-buffer-gbp`. It is the maximum
+The most important argument is `--refund-buffer`. It is the maximum
 amount of cancellation fee you are willing to incur if a commitment turns
-out badly. Microsoft currently charges a 12% cancellation fee on
-Reservations and Savings Plans (subject to change), so:
+out badly, expressed in your tenant's billing currency (auto-detected
+via `az billing account list` — see `--currency-symbol` to override).
+Microsoft currently charges a 12% cancellation fee on Reservations and
+Savings Plans (subject to change), so:
 
 ```
 Maximum committable annual spend ≈ buffer / 0.12
-e.g. £5,000 buffer ≈ £41,666 of safely-cancellable annual commit.
+e.g. 5,000 buffer ≈ 41,666 of safely-cancellable annual commit.
 ```
 
 This is intentionally a **business choice**, not a technical one. Setting
 the buffer too low caps your savings; setting it too high turns a forecast
 miss into a real refund cost. Common starting points:
 
-- **£5k** for a first-time customer with no commit history.
-- **£15k–£25k** for a tenant with > £1M annual VM spend and a
+- **5k** for a first-time customer with no commit history.
+- **15k–25k** for a tenant with substantial VM spend and a
   capacity-planning function.
-- **`--refund-buffer-gbp 0`** to suppress the buffer guardrail entirely
+- **`--refund-buffer 0`** to suppress the buffer guardrail entirely
   (the shortlist becomes "everything stable enough to commit").
+
+> **Deprecated**: `--refund-buffer-gbp` is still accepted as an alias
+> for `--refund-buffer` for one release so existing CI workflows keep
+> working; using it prints a deprecation warning. Update before v0.3.0.
 
 ## Limitations & assumptions
 

--- a/tools/ri-coverage/ri_coverage.py
+++ b/tools/ri-coverage/ri_coverage.py
@@ -25,7 +25,7 @@ Usage
     python ri_coverage.py \
         --subs <subId>[,<subId>...] \
         --months 3 \
-        --refund-buffer-gbp 5000 \
+        --refund-buffer 5000 \
         --out-dir ./out/ri-coverage
 
 Auth: relies on `az login`. Uses `az rest` to call Cost Management (avoids
@@ -54,6 +54,15 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from html_sink import write_html, write_index  # noqa: E402
+from finops_currency import detect_currency  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Display currency (overridden at run() time from CLI / billing-account auto-detect).
+# Defaults to GBP so existing fixtures / sample snapshots keep passing without
+# touching them.
+# ---------------------------------------------------------------------------
+CURRENCY: str = "£"
+CURRENCY_ISO: str = "GBP"
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -319,8 +328,9 @@ def score(g: Group) -> Recommendation:
         bits.append(f"⚠️  Family '{g.family}' is older-gen — verify "
                     "migration roadmap before committing 3Y.")
     if g.annual_payg < 5000:
-        bits.append("Annual PAYG burn under £5k — modest savings; consider "
-                    "rolling into a wider Compute SP rather than per-family RI.")
+        bits.append(f"Annual PAYG burn under {gbp(5000)} — modest savings; "
+                    "consider rolling into a wider Compute SP rather than "
+                    "per-family RI.")
 
     if cv < CV_MED and not deprecated:
         risk = "LOW"
@@ -366,8 +376,8 @@ def build_shortlist(recs, refund_buffer_gbp, min_savings_gbp: float = 50.0):
 
 def gbp(x: float) -> str:
     if abs(x) >= 1000:
-        return f"£{x:,.0f}"
-    return f"£{x:,.2f}"
+        return f"{CURRENCY}{x:,.0f}"
+    return f"{CURRENCY}{x:,.2f}"
 
 
 def write_coverage_csv(path: Path, recs):
@@ -415,7 +425,7 @@ def write_coverage_md(path: Path, recs, months: int, sub_count: int):
         f"- LOW-risk groups: **{by_risk['LOW']}** | "
         f"MEDIUM: **{by_risk['MEDIUM']}** | HIGH: **{by_risk['HIGH']}**",
         "",
-        "## Top 20 commitable groups (by annual PAYG £)",
+        "## Top 20 commitable groups (by annual PAYG)",
         "",
         "| Family | Region | Subs | Mo. PAYG | Yr PAYG | CV | Stability | "
         "Product | Yr commit | Yr savings | Risk |",
@@ -525,9 +535,23 @@ def write_shortlist_md(path: Path, shortlist, all_recs, buffer_gbp):
 # Orchestration
 # ---------------------------------------------------------------------------
 
-def run(subs, months, refund_buffer, out_dir: Path):
+def run(subs, months, refund_buffer, out_dir: Path, *,
+        currency_symbol: str | None = None):
     out_dir.mkdir(parents=True, exist_ok=True)
     date = datetime.now(timezone.utc).strftime("%Y%m%d")
+
+    global CURRENCY, CURRENCY_ISO
+    sym, iso, source = detect_currency(currency_symbol)
+    CURRENCY = sym
+    CURRENCY_ISO = iso or CURRENCY_ISO
+    src_label = {
+        "override": "from --currency-symbol",
+        "billing-account": "from `az billing account list`",
+        "default": "default — set --currency-symbol or grant Billing "
+                   "Reader to silence this",
+    }.get(source, source)
+    print(f"[engine] Display currency: {CURRENCY} "
+          f"({CURRENCY_ISO or '?'}) — {src_label}")
 
     print(f"[engine] Pulling {months}-month PAYG VM costs across "
           f"{len(subs)} sub(s)…")
@@ -548,7 +572,7 @@ def run(subs, months, refund_buffer, out_dir: Path):
     recs = [score(g) for g in groups.values() if g.annual_payg > 0]
     print(f"[engine] {len(recs)} family×region groups identified.")
     shortlist = build_shortlist(recs, refund_buffer)
-    print(f"[engine] Shortlist within £{refund_buffer:.0f} buffer: "
+    print(f"[engine] Shortlist within {gbp(refund_buffer)} buffer: "
           f"{len(shortlist)} recommendation(s).")
 
     coverage_csv  = out_dir / f"ri-coverage-{date}.csv"
@@ -574,7 +598,7 @@ def run(subs, months, refund_buffer, out_dir: Path):
     print(f"  - {shortlist_md}")
     print(f"  - {shortlist_html}")
     print(f"[engine] Modelled annual savings on shortlist: "
-          f"£{total_savings:,.0f}")
+          f"{gbp(total_savings)}")
 
 
 def main():
@@ -599,12 +623,46 @@ def main():
                          "Enabled (default: skip them).")
     ap.add_argument("--months", type=int, default=3,
                     help="Months of history to pull (default 3).")
-    ap.add_argument("--refund-buffer-gbp", type=float, default=5000.0,
-                    help="Cap on cumulative cancellation exposure (default 5000).")
+    # Buffer flag: prefer --refund-buffer (currency-agnostic). Keep
+    # --refund-buffer-gbp as a deprecated alias so existing CI workflows
+    # don't break in the same release that introduces auto-currency.
+    buffer_grp = ap.add_mutually_exclusive_group()
+    buffer_grp.add_argument(
+        "--refund-buffer", type=float, default=None, dest="refund_buffer",
+        help="Cap on cumulative cancellation exposure, in tenant billing "
+             "currency (default 5000).",
+    )
+    buffer_grp.add_argument(
+        "--refund-buffer-gbp", type=float, default=None,
+        dest="refund_buffer_gbp",
+        help="DEPRECATED alias for --refund-buffer; kept for backwards "
+             "compatibility with existing automation.",
+    )
+    ap.add_argument(
+        "--currency-symbol", type=str, default=None,
+        help="Override the auto-detected display currency glyph (e.g. "
+             "'$', '€', 'kr'). When omitted, the engine calls "
+             "`az billing account list` once to read the tenant's "
+             "billing currency and falls back to '£' on any failure.",
+    )
     ap.add_argument("--out-dir", required=True, help="Output directory.")
     args = ap.parse_args()
+    if args.refund_buffer is not None and args.refund_buffer_gbp is not None:
+        ap.error("--refund-buffer and --refund-buffer-gbp are mutually exclusive; "
+                 "use --refund-buffer.")
+    if args.refund_buffer_gbp is not None:
+        print("[engine] WARNING: --refund-buffer-gbp is deprecated; "
+              "use --refund-buffer.", file=sys.stderr)
+    refund_buffer = (
+        args.refund_buffer
+        if args.refund_buffer is not None
+        else args.refund_buffer_gbp
+        if args.refund_buffer_gbp is not None
+        else 5000.0
+    )
     subs = _resolve_subs(args)
-    run(subs, args.months, args.refund_buffer_gbp, Path(args.out_dir))
+    run(subs, args.months, refund_buffer, Path(args.out_dir),
+        currency_symbol=args.currency_symbol)
 
 
 def _resolve_subs(args) -> list[str]:


### PR DESCRIPTION
Closes #14.

## Summary

Engines now auto-detect the tenant billing currency at startup instead of hard-coding `£`. Adds a shared helper (`tools/finops_currency.py`) that calls `az billing account list` once, maps the ISO-4217 code to a display glyph (USD `$`, EUR `€`, SEK `kr`, JPY `¥`, INR `₹`, … 18 codes mapped, unknown codes fall back to the raw ISO), and threads the symbol through every report header, table, top-25 offender list, and per-owner Issue body.

Three engines wired up:

| Engine | Changes |
|---|---|
| `hidden-waste` | New `--currency-symbol` flag; module-level `CURRENCY` constant; column headers shifted to currency-agnostic wording (`Monthly cost` instead of `Monthly £`). |
| `ri-coverage` | New `--currency-symbol` flag; `--refund-buffer-gbp` **renamed to `--refund-buffer`** with the GBP-suffixed alias kept as a deprecated alternative for one release. Mutually exclusive group rejects both at once; using the alias prints a deprecation warning to stderr. |
| `context-enricher` | New `--currency-symbol` flag; rationale text and per-owner Issue bodies now interpolate the detected glyph. The CSV `rationale` column still produces `£150/mo` by default — fixture intact. |

The fourth engine (`rightsizing-peak`) doesn't print money, so it's untouched.

## Detection contract

- **Override wins** — `--currency-symbol '$'` short-circuits the subprocess call and is returned verbatim (multi-character glyphs supported).
- **Auto-detect via Azure CLI** — `az billing account list --only-show-errors -o json` with a 20s timeout. Three response shapes covered: MCA (`soldToInfo.billingCurrency`), EA (`properties.currency`), top-level fallback.
- **Never raises** — any subprocess error, JSON parse failure, missing field, or empty list falls back silently to `£` (`GBP`, source `default`). Engines print a one-line provenance message at startup so operators can see where the symbol came from.

This means **every existing snapshot, fixture, sample MD, and HTML report keeps passing without modification** — the default code path on a tenant where detection fails (e.g. CI without Billing Reader) is bit-for-bit identical to the pre-PR behaviour.

## Tests

- `tests/test_finops_currency.py` — 18 new unit tests covering all three resolution branches, every documented response shape, and 8 parameterised failure modes (non-zero return code, empty stdout, malformed JSON, wrong root type, missing currency field, `OSError`, `TimeoutExpired`, …). Subprocess mocked throughout — no live Azure calls.
- Engine `run()` paths bypass detection entirely and inherit the `£` default, so existing engine tests are unchanged.
- Full suite: **69 passed** (51 baseline + 18 new).

## Docs / changelog

- `docs/faq.md` — replaced the search-replace workaround with the new auto-detect / `--currency-symbol` story.
- Engine READMEs — documented the new flag in the scope-flags table.
- `CHANGELOG.md` — Unreleased entry under Added (currency detect) and Changed (flag rename + deprecation note).
- `ROADMAP.md` — strikethrough on the 🟢 currency bullet, link back to #14.
- `automation/finops-nightly.yml` — switched to the new `--refund-buffer` flag (alias still works, but no point keeping deprecated invocations in our own automation).

## Backwards compatibility

- `--refund-buffer-gbp` continues to work for one release (warning on stderr).
- All existing snapshot fixtures unchanged.
- No version bump in `pyproject.toml` — additive flag + alias keeps the API additive within v0.2.x. Defer cutting v0.3.0 (which would remove the deprecated alias) to a follow-up.