### PR TITLE
feat(rightsizing-peak): UPSIZE verdict + SKU-family swap (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ as detailed in [`VERSIONING.md`](./VERSIONING.md).
 
 ### Added
 
+- **`rightsizing-peak`: upsize targets and SKU-family swap suggestions
+  (issue [#9](https://github.com/prbeegala/FinOpsEngine/issues/9)).**
+  The engine now emits an `UPSIZE` verdict (replacing the old
+  `UPSIZE_WARNING`) with a recommended target SKU drawn from a new
+  `UPSIZE_LADDER` (mirror of the existing `DOWNSIZE_LADDER`). It also
+  populates a new CSV column, `recommended_sku`, with modernization
+  suggestions independent of the verdict — Dv3/DSv2 → Dasv5 and Ev3 →
+  Easv5 (typically 10–20% cheaper at matching shape), and a B-series
+  swap for `DOWNSIZE_CANDIDATE` VMs whose P95 CPU < 15% (low duty
+  cycle). The `--upsize-cpu-p95-min` / `--upsize-mem-p95-min` flags
+  drive the `UPSIZE` threshold (unchanged behaviour). README updated
+  with the swap tables. Existing `DOWNSIZE_CANDIDATE` / `KEEP` /
+  `INSUFFICIENT_DATA` verdicts are unchanged.
+
 - **Currency auto-detect across all engines (issue [#14](https://github.com/prbeegala/FinOpsEngine/issues/14)).**
   `hidden-waste`, `ri-coverage`, and `context-enricher` now call
   `az billing account list` once at startup, read the tenant's billing

--- a/docs/build_overview_pptx.py
+++ b/docs/build_overview_pptx.py
@@ -330,7 +330,7 @@ def slide_rightsizing(prs):
              "30 days + per-hour true peaks.",
         points=[
             "30 days of per-hour Max CPU + Min memory from Azure Monitor.",
-            "Per-VM verdict: DOWNSIZE / KEEP / UPSIZE_WARNING / "
+            "Per-VM verdict: DOWNSIZE / KEEP / UPSIZE / "
             "INSUFFICIENT_DATA.",
             "Cross-checks Advisor and flags any of its downsizes the "
             "engine deems unsafe.",

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,7 +40,7 @@ fallback for resources the bill has never seen.
 |---|---|---|
 | **`hidden-waste`** | Cost Management `ActualCost`, last 30 days, grouped by `ResourceId`. | Each row is tagged with a **cost source**: `cost_mgmt` (real billed £), `estimate` (list-price fallback for never-attached disks), `unknown` (no attribution — flagged for manual review). |
 | **`ri-coverage`** | Cost Management `ActualCost`, last N months, filtered to `MeterCategory = Virtual Machines` and `PricingModel = OnDemand`. | RI / Savings Plan discount %s come from public Microsoft commitment tables (1Y/3Y × RI/SP) and are applied on top of your real PAYG run-rate. Microsoft does not expose your *negotiated* RI/SP rate via API, so this is unavoidable. |
-| **`rightsizing-peak`** | Does not compute £ savings itself. | Produces verdicts (DOWNSIZE / KEEP / UPSIZE_WARNING / INSUFFICIENT_DATA). Where £ savings appear in the diff against Advisor, the figure is **Advisor's own modeled annual savings** (Advisor uses retail list price). Pair with `hidden-waste` via `context-enricher` for a verdict + actual-bill view per VM. |
+| **`rightsizing-peak`** | Does not compute £ savings itself. | Produces verdicts (DOWNSIZE / KEEP / UPSIZE / INSUFFICIENT_DATA). Where £ savings appear in the diff against Advisor, the figure is **Advisor's own modeled annual savings** (Advisor uses retail list price). Pair with `hidden-waste` via `context-enricher` for a verdict + actual-bill view per VM. |
 
 In practice this means EA / MCA discounts, regional pricing, Hybrid Benefit,
 dev/test rates and any private negotiated pricing are **already baked in**

--- a/tests/fixtures/rightsizing-peak/low-duty-b-swap.json
+++ b/tests/fixtures/rightsizing-peak/low-duty-b-swap.json
@@ -1,0 +1,20 @@
+{
+  "_doc": "Very low CPU on D2s_v3 → DOWNSIZE_CANDIDATE plus B-series swap recommendation (low-duty cycle).",
+  "vm": {
+    "subscription_id": "00000000-0000-0000-0000-000000000001",
+    "resource_group": "rg-test",
+    "name": "vm-idle",
+    "resource_id": "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-idle",
+    "vm_size": "Standard_D2s_v3",
+    "location": "uksouth",
+    "power_state": "VM running"
+  },
+  "samples": 168,
+  "cpu_avg": 3.0,
+  "cpu_max": 7.0,
+  "mem_used_pct": 12.0,
+  "expected_verdict": "DOWNSIZE_CANDIDATE",
+  "expected_confidence": "HIGH",
+  "expected_target_sku": "",
+  "expected_recommended_sku": "Standard_B2ms"
+}

--- a/tests/fixtures/rightsizing-peak/sku-family-swap.json
+++ b/tests/fixtures/rightsizing-peak/sku-family-swap.json
@@ -1,0 +1,20 @@
+{
+  "_doc": "Dv3 SKU at moderate utilization → KEEP verdict but recommended_sku populated with Dasv5 modernization swap.",
+  "vm": {
+    "subscription_id": "00000000-0000-0000-0000-000000000001",
+    "resource_group": "rg-test",
+    "name": "vm-old-family",
+    "resource_id": "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-old-family",
+    "vm_size": "Standard_D4_v3",
+    "location": "uksouth",
+    "power_state": "VM running"
+  },
+  "samples": 168,
+  "cpu_avg": 50.0,
+  "cpu_max": 65.0,
+  "mem_used_pct": 60.0,
+  "expected_verdict": "KEEP",
+  "expected_confidence": "HIGH",
+  "expected_target_sku": "",
+  "expected_recommended_sku": "Standard_D4as_v5"
+}

--- a/tests/fixtures/rightsizing-peak/upsize.json
+++ b/tests/fixtures/rightsizing-peak/upsize.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "P95 CPU above 80% → UPSIZE_WARNING. No target_sku in this engine (upsize ladder is roadmap).",
+  "_doc": "P95 CPU above 80% → UPSIZE verdict with target SKU from upsize ladder.",
   "vm": {
     "subscription_id": "00000000-0000-0000-0000-000000000001",
     "resource_group": "rg-test",
@@ -13,7 +13,8 @@
   "cpu_avg": 65.0,
   "cpu_max": 92.0,
   "mem_used_pct": 70.0,
-  "expected_verdict": "UPSIZE_WARNING",
+  "expected_verdict": "UPSIZE",
   "expected_confidence": "HIGH",
-  "expected_target_sku": ""
+  "expected_target_sku": "Standard_D8ds_v5"
 }
+

--- a/tests/test_rightsizing_peak.py
+++ b/tests/test_rightsizing_peak.py
@@ -5,7 +5,7 @@ Each ``tests/fixtures/rightsizing-peak/*.json`` file declares:
 * ``samples``             — number of metric points to broadcast
 * ``cpu_avg``/``cpu_max``/``mem_used_pct`` — scalar (broadcast),
   list (explicit), or ``{"base","spike","spike_count"}`` (mixed)
-* ``expected_verdict``    — DOWNSIZE_CANDIDATE / KEEP / UPSIZE_WARNING / INSUFFICIENT_DATA
+* ``expected_verdict``    — DOWNSIZE_CANDIDATE / KEEP / UPSIZE / INSUFFICIENT_DATA
 * ``expected_confidence`` — HIGH / MEDIUM / "" (insufficient data)
 * ``expected_target_sku`` — ladder target, or "" if engine doesn't propose one
 
@@ -56,10 +56,12 @@ def test_analyse_vm_matches_expected(rightsizing_peak, fixture_path):
     cpu_max = _expand(spec["cpu_max"], samples, "cpu_max")
     mem_used = _expand(spec["mem_used_pct"], samples, "mem_used_pct")
 
-    # Stable SKU catalogue — Standard_D4s_v5 has 4 vCPU / 16 GiB
+    # Stable SKU catalogue — covers all SKUs referenced by fixtures.
     sku_cat = {
         "Standard_D4ds_v5": rp.SkuCapacity(vcpus=4, memory_gb=16.0),
         "Standard_D2ds_v5": rp.SkuCapacity(vcpus=2, memory_gb=8.0),
+        "Standard_D4_v3":   rp.SkuCapacity(vcpus=4, memory_gb=16.0),
+        "Standard_D2s_v3":  rp.SkuCapacity(vcpus=2, memory_gb=8.0),
     }
     total_bytes = sku_cat[spec["vm"]["vm_size"]].memory_gb * 1024 ** 3
     mem_min_bytes = [(1.0 - pct / 100.0) * total_bytes for pct in mem_used]
@@ -92,6 +94,11 @@ def test_analyse_vm_matches_expected(rightsizing_peak, fixture_path):
     )
     assert result.target_sku == spec["expected_target_sku"], (
         f"target_sku mismatch for verdict {result.verdict}"
+    )
+    expected_rec = spec.get("expected_recommended_sku", "")
+    assert result.recommended_sku == expected_rec, (
+        f"recommended_sku mismatch for verdict {result.verdict}: "
+        f"got {result.recommended_sku!r}, want {expected_rec!r}"
     )
 
 

--- a/tests/test_rightsizing_peak.py
+++ b/tests/test_rightsizing_peak.py
@@ -56,7 +56,8 @@ def test_analyse_vm_matches_expected(rightsizing_peak, fixture_path):
     cpu_max = _expand(spec["cpu_max"], samples, "cpu_max")
     mem_used = _expand(spec["mem_used_pct"], samples, "mem_used_pct")
 
-    # Stable SKU catalogue — covers all SKUs referenced by fixtures.
+    # Stable SKU catalogue — only needs to cover fixture input ``vm_size``
+    # values used here to compute total memory bytes for the fake metrics.
     sku_cat = {
         "Standard_D4ds_v5": rp.SkuCapacity(vcpus=4, memory_gb=16.0),
         "Standard_D2ds_v5": rp.SkuCapacity(vcpus=2, memory_gb=8.0),

--- a/tools/rightsizing-peak/README.md
+++ b/tools/rightsizing-peak/README.md
@@ -33,13 +33,18 @@ For every non-managed VM in the target subscription(s):
 3. Applies a deterministic decision tree:
    - `DOWNSIZE_CANDIDATE` if P95 CPU < 40% AND P95 mem-used < 50%.
      `HIGH` confidence when P99 is also low; `MEDIUM` otherwise.
-   - `UPSIZE_WARNING` if P95 CPU ≥ 80% OR P95 mem-used ≥ 85%.
+   - `UPSIZE` if P95 CPU ≥ 80% OR P95 mem-used ≥ 85% — emits a target
+     SKU one step up the same family/generation when an `UPSIZE_LADDER`
+     entry exists, blank for manual review otherwise.
    - `INSUFFICIENT_DATA` if metric coverage < 80% of the window.
    - `KEEP` otherwise.
-4. **Diffs against Azure Advisor**: every Advisor "Cost — Resize VM"
-   recommendation where this engine emits `UPSIZE_WARNING` or `KEEP` is
+4. **SKU-family swap** suggestions (independent of the up/downsize verdict):
+   modernization opportunities written to a `recommended_sku` column —
+   typically 10–20% saving at equal-or-better performance.
+5. **Diffs against Azure Advisor**: every Advisor "Cost — Resize VM"
+   recommendation where this engine emits `UPSIZE` or `KEEP` is
    flagged `advisor_unsafe = true`. *This is the headline metric.*
-5. Emits per-subscription Markdown + CSV reports plus a combined roll-up.
+6. Emits per-subscription Markdown + CSV reports plus a combined roll-up.
 
 ## Excluded by design
 
@@ -92,7 +97,8 @@ engine).
 ## Outputs
 
 - `<sub>-peak-rightsizing-<date>.csv` — one row per VM with all metrics +
-  decision + confidence + proposed_size + advisor_unsafe.
+  decision + confidence + `target_sku` (same-family up/downsize) +
+  `recommended_sku` (modernization swap) + `advisor_unsafe`.
 - `<sub>-peak-rightsizing-<date>.md` — human-readable per-sub summary.
 - `peak-rightsizing-combined-<date>.md` — roll-up table + headline number.
 
@@ -174,12 +180,51 @@ count is the threshold or the workload.
 
 ### Adding new SKU families
 
-The `DOWNSIZE_LADDER` map (also in the source file) is the *only* place an
-explicit target SKU is proposed. If the current size has no entry there, the
-engine still emits `DOWNSIZE_CANDIDATE` — but leaves `target_sku` blank and
-defers the choice to the human reviewer. Adding ladder entries is the
-recommended way to expand the engine's coverage; heuristic-derived targets
-are deliberately not generated.
+Three lookup tables in `rightsizing_peak.py` drive SKU recommendations:
+
+- `DOWNSIZE_LADDER` — proposes one step smaller in the same family/generation
+  for `DOWNSIZE_CANDIDATE` verdicts.
+- `UPSIZE_LADDER` — mirror of `DOWNSIZE_LADDER`, used to populate
+  `target_sku` on `UPSIZE` verdicts.
+- `SKU_FAMILY_SWAP` and `LOW_DUTY_B_SWAP` — populate the
+  `recommended_sku` column independently of the verdict (see below).
+
+If the current size has no entry in the relevant ladder the engine still
+emits the verdict — but leaves `target_sku` blank and defers the choice
+to the human reviewer. Adding ladder entries is the recommended way to
+expand coverage; heuristic-derived targets are deliberately not generated.
+
+### SKU-family swap (`recommended_sku` column)
+
+In addition to the same-family up/downsize ladders, the engine emits a
+`recommended_sku` column with modernization suggestions independent of
+the verdict. Typical savings are 10–20% at equal-or-better performance.
+
+| From (older / Intel) | To (modern / AMD) | Why |
+|---|---|---|
+| `Standard_D{2,4,8,16}_v3` / `_v4` / `s_v3` | `Standard_D{N}as_v5` | Dasv5 (AMD EPYC, premium SSD) is consistently cheaper than Dv3/Dsv3/Dv4 at matching vCPU/memory. |
+| `Standard_DS{2,3,4,5}_v2` | `Standard_D{2,4,8,16}as_v5` | DSv2 is older Intel; Dasv5 saves ~15-20% at matching shape. |
+| `Standard_E{2,4,8,16}_v3` / `s_v3` | `Standard_E{N}as_v5` | Easv5 is the AMD memory-optimized equivalent. |
+
+For low-duty-cycle workloads (P95 CPU < 15% **and** verdict =
+`DOWNSIZE_CANDIDATE`), the engine instead recommends a B-series swap at
+matching capacity:
+
+| From | To |
+|---|---|
+| `Standard_D2*_v{3,5}` / `Standard_DS2_v2` | `Standard_B2ms` |
+| `Standard_D4*_v{3,5}` / `Standard_DS3_v2` | `Standard_B4ms` |
+| `Standard_D8*_v{3,5}` / `Standard_DS4_v2` | `Standard_B8ms` |
+
+B-series accumulates CPU credits during idle periods and bursts above its
+baseline when needed — strictly cheaper than a same-shape D/E SKU when
+the duty cycle is low. Confirm the workload's burst pattern fits within
+the B-series credit ceiling before applying.
+
+`recommended_sku` is informational — it is **not** the same as
+`target_sku` (the same-family ladder target). A VM can have both: e.g.
+`Standard_D4_v3` → `target_sku=Standard_D2_v3` (downsize ladder),
+`recommended_sku=Standard_D4as_v5` (family modernization).
 
 ## Why peak-aware matters — and where Advisor falls short
 

--- a/tools/rightsizing-peak/rightsizing_peak.py
+++ b/tools/rightsizing-peak/rightsizing_peak.py
@@ -126,6 +126,111 @@ DOWNSIZE_LADDER = {
     "Standard_L16s": "Standard_L8s",
 }
 
+# Family upsize ladders (one step larger in same family/generation).
+# Mirror of DOWNSIZE_LADDER. Engine only proposes a target SKU if it's in
+# this map; otherwise it emits the verdict (UPSIZE) but leaves target_sku
+# blank for manual review.
+UPSIZE_LADDER = {
+    # D/Ds v3
+    "Standard_D2_v3": "Standard_D4_v3",
+    "Standard_D4_v3": "Standard_D8_v3",
+    "Standard_D2s_v3": "Standard_D4s_v3",
+    "Standard_D4s_v3": "Standard_D8s_v3",
+    "Standard_DS2_v2": "Standard_DS3_v2",
+    "Standard_DS4_v2": "Standard_DS5_v2",
+    # D v4 / v5
+    "Standard_D2_v4": "Standard_D4_v4",
+    "Standard_D4_v4": "Standard_D8_v4",
+    "Standard_D2ds_v5": "Standard_D4ds_v5",
+    "Standard_D4ds_v5": "Standard_D8ds_v5",
+    "Standard_D8ds_v5": "Standard_D16ds_v5",
+    "Standard_D2ads_v5": "Standard_D4ads_v5",
+    "Standard_D4ads_v5": "Standard_D8ads_v5",
+    "Standard_D8ads_v5": "Standard_D16ads_v5",
+    # E series
+    "Standard_E2ds_v4": "Standard_E4ds_v4",
+    "Standard_E4ds_v4": "Standard_E8ds_v4",
+    "Standard_E8ds_v4": "Standard_E16ds_v4",
+    "Standard_E2ds_v5": "Standard_E4ds_v5",
+    "Standard_E4ds_v5": "Standard_E8ds_v5",
+    "Standard_E8ds_v5": "Standard_E16ds_v5",
+    "Standard_E2ads_v5": "Standard_E4ads_v5",
+    "Standard_E4ads_v5": "Standard_E8ads_v5",
+    "Standard_E4as_v5": "Standard_E8as_v5",
+    "Standard_E8as_v5": "Standard_E16as_v5",
+    # F series
+    "Standard_F2s_v2": "Standard_F4s_v2",
+    "Standard_F4s_v2": "Standard_F8s_v2",
+    "Standard_F8s_v2": "Standard_F16s_v2",
+    # B series
+    "Standard_B2ms": "Standard_B4ms",
+    "Standard_B4ms": "Standard_B8ms",
+    # L series
+    "Standard_L4s": "Standard_L8s",
+    "Standard_L8s": "Standard_L16s",
+}
+
+# SKU-family modernization swaps. Maps an older-generation SKU to a
+# modern AMD (`asv5`) equivalent at the same vCPU/memory shape, which
+# typically saves 10–20% at equal or better performance. Source: Azure
+# VM pricing pages (compare retail $/hr for the source vs target SKU in
+# the same region; Dasv5 / Easv5 are consistently cheaper than the
+# corresponding Dv3 / DSv2 / Ev3 SKUs at matching size).
+SKU_FAMILY_SWAP = {
+    # Dv3 / Dsv3 → Dasv5 (AMD EPYC, premium SSD)
+    "Standard_D2_v3":  "Standard_D2as_v5",
+    "Standard_D4_v3":  "Standard_D4as_v5",
+    "Standard_D8_v3":  "Standard_D8as_v5",
+    "Standard_D16_v3": "Standard_D16as_v5",
+    "Standard_D2s_v3":  "Standard_D2as_v5",
+    "Standard_D4s_v3":  "Standard_D4as_v5",
+    "Standard_D8s_v3":  "Standard_D8as_v5",
+    "Standard_D16s_v3": "Standard_D16as_v5",
+    # Older DSv2 → Dasv5
+    "Standard_DS2_v2": "Standard_D2as_v5",
+    "Standard_DS3_v2": "Standard_D4as_v5",
+    "Standard_DS4_v2": "Standard_D8as_v5",
+    "Standard_DS5_v2": "Standard_D16as_v5",
+    # Ev3 / Esv3 → Easv5 (memory-optimized AMD)
+    "Standard_E2_v3":  "Standard_E2as_v5",
+    "Standard_E4_v3":  "Standard_E4as_v5",
+    "Standard_E8_v3":  "Standard_E8as_v5",
+    "Standard_E16_v3": "Standard_E16as_v5",
+    "Standard_E2s_v3":  "Standard_E2as_v5",
+    "Standard_E4s_v3":  "Standard_E4as_v5",
+    "Standard_E8s_v3":  "Standard_E8as_v5",
+    "Standard_E16s_v3": "Standard_E16as_v5",
+    # Dv4 → Dasv5 (Dv4 is Intel; Dasv5 typically cheaper at same shape)
+    "Standard_D2_v4": "Standard_D2as_v5",
+    "Standard_D4_v4": "Standard_D4as_v5",
+    "Standard_D8_v4": "Standard_D8as_v5",
+}
+
+# Low-duty-cycle swap to B-series. Applied only when a VM is already a
+# DOWNSIZE_CANDIDATE *and* CPU P95 max is below LOW_DUTY_CPU_P95_MAX,
+# meaning the workload is bursty/idle enough that B-series credit
+# accounting will be a net win.
+LOW_DUTY_CPU_P95_MAX = 15.0
+LOW_DUTY_B_SWAP = {
+    # Map source SKU shape → B-series equivalent at the same vCPU/memory.
+    # Only includes shapes where a B-series SKU exists at matching capacity.
+    "Standard_D2s_v3":   "Standard_B2ms",
+    "Standard_D2_v3":    "Standard_B2ms",
+    "Standard_D2ds_v5":  "Standard_B2ms",
+    "Standard_D2ads_v5": "Standard_B2ms",
+    "Standard_D4s_v3":   "Standard_B4ms",
+    "Standard_D4_v3":    "Standard_B4ms",
+    "Standard_D4ds_v5":  "Standard_B4ms",
+    "Standard_D4ads_v5": "Standard_B4ms",
+    "Standard_D8s_v3":   "Standard_B8ms",
+    "Standard_D8_v3":    "Standard_B8ms",
+    "Standard_D8ds_v5":  "Standard_B8ms",
+    "Standard_D8ads_v5": "Standard_B8ms",
+    "Standard_DS2_v2":   "Standard_B2ms",
+    "Standard_DS3_v2":   "Standard_B4ms",
+    "Standard_DS4_v2":   "Standard_B8ms",
+}
+
 # Resource Graph query — non-managed VMs only
 VM_QUERY = """
 Resources
@@ -168,6 +273,7 @@ class VmRecord:
     verdict: str = "UNKNOWN"
     confidence: str = ""
     target_sku: str = ""
+    recommended_sku: str = ""
     rationale: str = ""
     advisor_says: str = ""
     advisor_unsafe: bool = False
@@ -335,11 +441,12 @@ def analyse_vm(vm: VmRecord, *, days: int,
 
     if (cpu95 >= DECISION_RULES["upsize_cpu_p95_min"]
             or mem95 >= DECISION_RULES["upsize_mem_p95_min"]):
-        vm.verdict = "UPSIZE_WARNING"
+        vm.verdict = "UPSIZE"
         vm.confidence = "HIGH"
+        vm.target_sku = UPSIZE_LADDER.get(vm.vm_size, "")
         vm.rationale = (
-            f"P95 CPU {cpu95}% / P95 Mem {mem95}% — already at peak headroom. "
-            f"Do NOT downsize; consider upsize or scale-out."
+            f"P95 CPU {cpu95}% / P95 Mem {mem95}% — sustained over upsize "
+            f"threshold. Recommend upsize or scale-out; do NOT downsize."
         )
     elif (cpu95 < DECISION_RULES["downsize_cpu_p95_max"]
           and mem95 < DECISION_RULES["downsize_mem_p95_max"]):
@@ -361,6 +468,17 @@ def analyse_vm(vm: VmRecord, *, days: int,
             f"P95 CPU {cpu95}% / P95 Mem {mem95}% — between thresholds; "
             f"current size is appropriate."
         )
+
+    # SKU-family swap recommendation (independent of verdict).
+    # Priority: low-duty B-series swap (only for clear DOWNSIZE candidates
+    # with very low CPU P95) > family modernization (Dv3 → Dasv5 etc).
+    if (vm.verdict == "DOWNSIZE_CANDIDATE"
+            and cpu95 < LOW_DUTY_CPU_P95_MAX
+            and vm.vm_size in LOW_DUTY_B_SWAP):
+        vm.recommended_sku = LOW_DUTY_B_SWAP[vm.vm_size]
+    elif vm.vm_size in SKU_FAMILY_SWAP:
+        vm.recommended_sku = SKU_FAMILY_SWAP[vm.vm_size]
+
     return vm
 
 
@@ -424,7 +542,7 @@ def write_md_report(vms: list[VmRecord], sub_name: str, path: Path,
         "| Verdict | Count |",
         "|---|---:|",
     ]
-    for k in ["DOWNSIZE_CANDIDATE", "KEEP", "UPSIZE_WARNING",
+    for k in ["DOWNSIZE_CANDIDATE", "KEEP", "UPSIZE",
               "INSUFFICIENT_DATA", "UNKNOWN"]:
         if counts.get(k, 0):
             lines.append(f"| {k} | {counts[k]} |")
@@ -466,18 +584,42 @@ def write_md_report(vms: list[VmRecord], sub_name: str, path: Path,
             )
         lines.append("")
 
-    upsize = [v for v in vms if v.verdict == "UPSIZE_WARNING"]
+    upsize = [v for v in vms if v.verdict == "UPSIZE"]
     if upsize:
         lines += [
-            "## Capacity-headroom warnings (do not downsize)",
+            "## Upsize candidates (sustained peak headroom — do not downsize)",
             "",
-            "| VM | SKU | P95 CPU | P95 Mem | Rationale |",
+            "| VM | Current → Target | P95 CPU | P95 Mem | Rationale |",
             "|---|---|---:|---:|---|",
         ]
         for v in upsize:
+            tgt = v.target_sku or "_(no ladder match — review manually)_"
             lines.append(
-                f"| `{v.name}` | {v.vm_size} | {v.cpu_p95_max}% | "
-                f"{v.mem_used_p95}% | {v.rationale} |"
+                f"| `{v.name}` | {v.vm_size} → {tgt} | "
+                f"{v.cpu_p95_max}% | {v.mem_used_p95}% | {v.rationale} |"
+            )
+        lines.append("")
+
+    swap = [v for v in vms
+            if v.recommended_sku and v.recommended_sku != v.target_sku]
+    if swap:
+        lines += [
+            "## SKU-family swap suggestions",
+            "",
+            "Modernization opportunities independent of the up/downsize "
+            "verdict. Typical savings: 10–20% at equal or better "
+            "performance (Dv3/DSv2 → Dasv5, Ev3 → Easv5) or larger for "
+            "low-duty workloads moving to B-series.",
+            "",
+            "| VM | Verdict | Current → Recommended | P95 CPU | P95 Mem |",
+            "|---|---|---|---:|---:|",
+        ]
+        for v in swap:
+            cpu = f"{v.cpu_p95_max}%" if v.cpu_p95_max is not None else "—"
+            mem = f"{v.mem_used_p95}%" if v.mem_used_p95 is not None else "—"
+            lines.append(
+                f"| `{v.name}` | {v.verdict} | "
+                f"{v.vm_size} → {v.recommended_sku} | {cpu} | {mem} |"
             )
         lines.append("")
 
@@ -497,7 +639,7 @@ def write_md_report(vms: list[VmRecord], sub_name: str, path: Path,
         "- Excludes Databricks-managed (`databricks-rg-*`) and AKS node "
         "(`MC_*` / `aks-*`) VMs — those are managed by their parent service.",
         "- Advisor diff: any VM where Advisor recommends a downsize but "
-        "the engine emits `UPSIZE_WARNING` or `KEEP` is flagged as "
+        "the engine emits `UPSIZE` or `KEEP` is flagged as "
         "**advisor_unsafe**.",
         "",
         "_Generated by `rightsizing-peak`. Source: "
@@ -577,7 +719,7 @@ def run(subs: list[str], *, days: int, out_dir: Path,
             hit = adv.get(v.resource_id.lower())
             if hit:
                 v.advisor_says = hit
-                if v.verdict in ("UPSIZE_WARNING", "KEEP"):
+                if v.verdict in ("UPSIZE", "KEEP"):
                     v.advisor_unsafe = True
 
         csv_path = out_dir / f"{sub_name}-peak-rightsizing-{today}.csv"
@@ -616,28 +758,28 @@ def write_combined(summary: dict, out_dir: Path, today: str, days: int):
         "",
         "## Roll-up",
         "",
-        "| Subscription | VMs | Downsize | Keep | Upsize warn | Insufficient | Advisor unsafe |",
+        "| Subscription | VMs | Downsize | Keep | Upsize | Insufficient | Advisor unsafe |",
         "|---|---:|---:|---:|---:|---:|---:|",
     ]
     tot = {"vms": 0, "DOWNSIZE_CANDIDATE": 0, "KEEP": 0,
-           "UPSIZE_WARNING": 0, "INSUFFICIENT_DATA": 0, "advisor_unsafe": 0}
+           "UPSIZE": 0, "INSUFFICIENT_DATA": 0, "advisor_unsafe": 0}
     for s in summary["subscriptions"]:
         v = s["verdicts"]
         lines.append(
             f"| {s['name']} | {s['vms']} | "
             f"{v.get('DOWNSIZE_CANDIDATE',0)} | {v.get('KEEP',0)} | "
-            f"{v.get('UPSIZE_WARNING',0)} | "
+            f"{v.get('UPSIZE',0)} | "
             f"{v.get('INSUFFICIENT_DATA',0)} | {s['advisor_unsafe']} |"
         )
         tot["vms"] += s["vms"]
-        for k in ["DOWNSIZE_CANDIDATE", "KEEP", "UPSIZE_WARNING",
+        for k in ["DOWNSIZE_CANDIDATE", "KEEP", "UPSIZE",
                   "INSUFFICIENT_DATA"]:
             tot[k] += v.get(k, 0)
         tot["advisor_unsafe"] += s["advisor_unsafe"]
     lines.append(
         f"| **Total** | **{tot['vms']}** | "
         f"**{tot['DOWNSIZE_CANDIDATE']}** | **{tot['KEEP']}** | "
-        f"**{tot['UPSIZE_WARNING']}** | **{tot['INSUFFICIENT_DATA']}** | "
+        f"**{tot['UPSIZE']}** | **{tot['INSUFFICIENT_DATA']}** | "
         f"**{tot['advisor_unsafe']}** |"
     )
     lines += [
@@ -759,12 +901,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
                         "to HIGH confidence (default %(default)s).")
     g.add_argument("--upsize-cpu-p95-min", type=float,
                    default=DECISION_RULES["upsize_cpu_p95_min"],
-                   help="P95 CPU%% at or above this triggers UPSIZE_WARNING "
+                   help="P95 CPU%% at or above this triggers UPSIZE "
                         "(default %(default)s).")
     g.add_argument("--upsize-mem-p95-min", type=float,
                    default=DECISION_RULES["upsize_mem_p95_min"],
                    help="P95 memory-used%% at or above this triggers "
-                        "UPSIZE_WARNING (default %(default)s).")
+                        "UPSIZE (default %(default)s).")
     g.add_argument("--min-data-coverage", type=float,
                    default=DECISION_RULES["min_data_coverage"],
                    help="Fraction (0.0-1.0) of expected hourly samples "


### PR DESCRIPTION
Closes #9.

## Summary

Adds two missing buckets to `rightsizing-peak`:

1. **Upsize with target SKU** — the engine now emits an `UPSIZE` verdict (renamed from `UPSIZE_WARNING`) with a target SKU drawn from a new `UPSIZE_LADDER` (mirror of the existing `DOWNSIZE_LADDER`).
2. **SKU-family swap** — new `recommended_sku` CSV column, populated independently of the verdict:
   - Dv3 / DSv2 / Dv4 → Dasv5
   - Ev3 → Easv5
   - Low-duty-cycle D-series (verdict = `DOWNSIZE_CANDIDATE` and P95 CPU < 15%) → matching B-series

## Acceptance checklist

- [x] Uses existing `--upsize-cpu-p95-min` / `--upsize-mem-p95-min` flags (unchanged behaviour for the threshold itself).
- [x] README updated with the swap tables and explanation.
- [x] No regression on existing `DOWNSIZE_CANDIDATE` / `KEEP` / `INSUFFICIENT_DATA` verdicts (the renamed `UPSIZE_WARNING` → `UPSIZE` is intentional and the only verdict-name change).

## Tests

- Renamed fixture `upsize-warning.json` → `upsize.json` — now asserts `UPSIZE` + `target_sku=Standard_D8ds_v5`.
- New fixtures: `sku-family-swap.json` (Dv3 → Dasv5, verdict KEEP) and `low-duty-b-swap.json` (D2s_v3 → B2ms, verdict DOWNSIZE_CANDIDATE).
- Fixture-driven test now also asserts `recommended_sku`.
- All 71 tests pass.