### PR TITLE
feat(hidden-waste): dev/test auto-shutdown gap detector (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ as detailed in [`VERSIONING.md`](./VERSIONING.md).
 
 ### Added
 
+- **`hidden-waste`: dev/test auto-shutdown gap detector (issue
+  [#5](https://github.com/prbeegala/FinOpsEngine/issues/5)).** Three
+  new categories — `devtest_no_shutdown_vm`, `devtest_no_shutdown_sql`,
+  and `devtest_no_shutdown_aks` — flag non-production workloads
+  (`environment` / `env` tag in the canonical dev/test value list)
+  that bill 24×7 against a 12h × 5d target cadence. The VM detector
+  left-anti-joins against `microsoft.devtestlab/schedules`
+  (`ComputeVmShutdownTask`, `Enabled`) so VMs that already have a
+  shutdown schedule are excluded; it then verifies ≥95% hourly
+  Percentage CPU coverage over the last 14 days via Azure Monitor,
+  matching `rightsizing-peak`'s coverage methodology. SQL flags every
+  Azure SQL DB whose service tier isn't Serverless (`GP_S_*`) — the
+  only DTU/vCore tier that auto-pauses. AKS flags clusters in
+  `PowerState/Running` that could be paused via `az aks stop`. Savings
+  are computed as `monthly_bill × 108/168 ≈ 0.6429` (the wasted slice
+  vs the issue's explicit 12h × 5d target). New CLI flags
+  `--devtest-uptime-days` and `--devtest-uptime-threshold` tune the
+  evidence window. Tag-key tuples (`OWNER_KEYS`, `CRITICALITY_KEYS`,
+  `ENVIRONMENT_KEYS`, `COSTCENTRE_KEYS`, `APP_KEYS`,
+  `TAG_PLACEHOLDERS`) and the new `DEVTEST_ENV_VALUES` set are now
+  centralised in `tools/tag_keys.py`; `context-enricher` re-imports
+  them so the two engines can never disagree on what counts as
+  "dev/test".
+
 - **`rightsizing-peak`: upsize targets and SKU-family swap suggestions
   (issue [#9](https://github.com/prbeegala/FinOpsEngine/issues/9)).**
   The engine now emits an `UPSIZE` verdict (replacing the old

--- a/tests/test_hidden_waste_devtest.py
+++ b/tests/test_hidden_waste_devtest.py
@@ -1,0 +1,228 @@
+"""Unit tests for ``hidden-waste``'s dev/test auto-shutdown gap detectors
+(issue #5).
+
+Covers:
+
+* Registry presence — three categories with labels, KQL embedding the
+  shared ``DEVTEST_ENV_VALUES`` list.
+* ``annotate_cost`` applies ``DEVTEST_WASTE_RATIO`` to the Cost-
+  Management bill; fallback when CM has no row.
+* ``refine_devtest_findings`` — VM uptime confirmation with metrics
+  monkey-patched out (skip-metrics, missing-metrics, low-coverage,
+  high-coverage paths). SQL/AKS pass through untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def hw(hidden_waste):
+    return hidden_waste
+
+
+def _vm(hw, **overrides):
+    defaults = dict(
+        category="devtest_no_shutdown_vm",
+        sub_id="00000000-0000-0000-0000-000000000000",
+        sub_name="test-sub",
+        rg="rg-dev",
+        name="vm-dev-1",
+        location="westeurope",
+        resource_id="/subscriptions/x/resourcegroups/rg-dev/providers/"
+                    "microsoft.compute/virtualmachines/vm-dev-1",
+        sku="Standard_D4ds_v5",
+        extra="dev",
+    )
+    defaults.update(overrides)
+    return hw.Finding(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Registry presence
+# ---------------------------------------------------------------------------
+
+def test_devtest_categories_registered(hw):
+    for cat in ("devtest_no_shutdown_vm", "devtest_no_shutdown_sql",
+                "devtest_no_shutdown_aks"):
+        assert cat in hw.QUERIES, f"missing query for {cat}"
+        assert cat in hw.CATEGORY_LABELS, f"missing label for {cat}"
+    assert hw.DEVTEST_CATS == frozenset({
+        "devtest_no_shutdown_vm",
+        "devtest_no_shutdown_sql",
+        "devtest_no_shutdown_aks",
+    })
+
+
+def test_devtest_queries_target_correct_resource_types(hw):
+    assert ("microsoft.compute/virtualmachines"
+            in hw.QUERIES["devtest_no_shutdown_vm"])
+    # VM detector must left/right-anti join against DTL shutdown
+    # schedules so VMs *with* a schedule are excluded.
+    assert ("microsoft.devtestlab/schedules"
+            in hw.QUERIES["devtest_no_shutdown_vm"])
+    assert "ComputeVmShutdownTask" in hw.QUERIES["devtest_no_shutdown_vm"]
+    assert "rightanti" in hw.QUERIES["devtest_no_shutdown_vm"]
+    # AKS-managed RGs and node-pool VMs must be excluded so we don't
+    # flag platform-spawned compute.
+    assert "databricks-rg-" in hw.QUERIES["devtest_no_shutdown_vm"]
+    assert "mc_" in hw.QUERIES["devtest_no_shutdown_vm"]
+
+    assert ("microsoft.sql/servers/databases"
+            in hw.QUERIES["devtest_no_shutdown_sql"])
+    # Serverless tier (auto-pause-capable) must be excluded.
+    assert "GP_S_" in hw.QUERIES["devtest_no_shutdown_sql"]
+
+    assert ("microsoft.containerservice/managedclusters"
+            in hw.QUERIES["devtest_no_shutdown_aks"])
+    # Only currently-running clusters are waste candidates.
+    assert "Running" in hw.QUERIES["devtest_no_shutdown_aks"]
+
+
+def test_queries_use_shared_devtest_value_list(hw):
+    # Each detector must filter on the same canonical env-tag value
+    # list so context-enricher and hidden-waste can never disagree.
+    from tag_keys import DEVTEST_ENV_VALUES
+    sample_values = ("dev", "test", "uat", "sandbox", "preprod",
+                     "non-prod", "staging")
+    for cat in ("devtest_no_shutdown_vm", "devtest_no_shutdown_sql",
+                "devtest_no_shutdown_aks"):
+        q = hw.QUERIES[cat]
+        for v in sample_values:
+            assert v in DEVTEST_ENV_VALUES, (
+                f"sample value {v!r} drifted out of DEVTEST_ENV_VALUES")
+            assert f"'{v}'" in q, f"{cat} missing dev/test value {v!r}"
+
+
+# ---------------------------------------------------------------------------
+# annotate_cost — wasted-ratio applied to CM, unknown otherwise
+# ---------------------------------------------------------------------------
+
+def test_devtest_vm_applies_waste_ratio_to_cm_bill(hw):
+    f = _vm(hw)
+    cost_map = {f.resource_id.lower(): 100.0}  # £100 over 30 days
+    hw.annotate_cost(f, cost_map, days=30)
+    assert f.cost_source == "cost_mgmt"
+    # 12h × 5d cadence vs 24×7 → 108/168 wasted.
+    assert f.monthly_gbp == pytest.approx(100.0 * (108.0 / 168.0))
+
+
+def test_devtest_sql_applies_waste_ratio_to_cm_bill(hw):
+    f = _vm(hw, category="devtest_no_shutdown_sql",
+            name="srv1/db1", sku="GP_Gen5_2")
+    cost_map = {f.resource_id.lower(): 70.0}
+    hw.annotate_cost(f, cost_map, days=30)
+    assert f.cost_source == "cost_mgmt"
+    assert f.monthly_gbp == pytest.approx(70.0 * hw.DEVTEST_WASTE_RATIO)
+
+
+def test_devtest_aks_falls_back_to_unknown_when_no_cm_row(hw):
+    f = _vm(hw, category="devtest_no_shutdown_aks", name="aks-dev")
+    hw.annotate_cost(f, {}, days=30)
+    assert f.cost_source == "unknown"
+    assert f.monthly_gbp == 0.0
+
+
+def test_non_devtest_categories_keep_full_monthly(hw):
+    # Sanity: my new branch must not affect the existing CM short-
+    # circuit for non-devtest categories.
+    f = hw.Finding(
+        category="unattached_disks",
+        sub_id="x", sub_name="test", rg="rg", name="disk1",
+        location="westeurope",
+        resource_id="/subscriptions/x/.../disk1",
+        sku="Premium_LRS", size_gb=128,
+    )
+    hw.annotate_cost(f, {f.resource_id.lower(): 30.0}, days=30)
+    assert f.monthly_gbp == pytest.approx(30.0)
+
+
+# ---------------------------------------------------------------------------
+# refine_devtest_findings
+# ---------------------------------------------------------------------------
+
+def test_refine_keeps_high_uptime_vm(hw, monkeypatch):
+    # 14d × 24h = 336 expected hourly samples; 320 ≈ 95.2% coverage.
+    monkeypatch.setattr(
+        hw, "az_metric_timeseries",
+        lambda rid, **kw: [10.0] * 320,
+    )
+    f = _vm(hw)
+    out = hw.refine_devtest_findings(
+        [f], uptime_days=14, uptime_threshold=0.95)
+    assert len(out) == 1
+    assert "uptime" in out[0].extra
+    assert "95%" in out[0].extra or "96%" in out[0].extra
+
+
+def test_refine_drops_low_uptime_vm(hw, monkeypatch):
+    # 14d × 24h = 336; 100 samples ≈ 30% coverage — drop.
+    monkeypatch.setattr(
+        hw, "az_metric_timeseries",
+        lambda rid, **kw: [10.0] * 100,
+    )
+    f = _vm(hw)
+    out = hw.refine_devtest_findings(
+        [f], uptime_days=14, uptime_threshold=0.95)
+    assert out == [], "intermittent VM should not be flagged"
+
+
+def test_refine_keeps_vm_when_metrics_unavailable(hw, monkeypatch):
+    # Best-effort: keep with explanatory tag rather than silently drop.
+    monkeypatch.setattr(
+        hw, "az_metric_timeseries",
+        lambda rid, **kw: None,
+    )
+    f = _vm(hw)
+    out = hw.refine_devtest_findings(
+        [f], uptime_days=14, uptime_threshold=0.95)
+    assert len(out) == 1
+    assert "uptime=unknown" in out[0].extra
+
+
+def test_refine_skip_metrics_keeps_all_vms(hw, monkeypatch):
+    # Should not call az_metric_timeseries at all.
+    def boom(*args, **kwargs):
+        raise AssertionError("metric call should be skipped")
+    monkeypatch.setattr(hw, "az_metric_timeseries", boom)
+    f = _vm(hw)
+    out = hw.refine_devtest_findings(
+        [f], uptime_days=14, uptime_threshold=0.95, skip_metrics=True)
+    assert len(out) == 1
+    assert "metric-skipped" in out[0].extra
+
+
+def test_refine_passes_through_sql_and_aks(hw, monkeypatch):
+    # Non-VM dev/test categories must not trigger metric calls.
+    def boom(*args, **kwargs):
+        raise AssertionError("metric call should not fire for SQL/AKS")
+    monkeypatch.setattr(hw, "az_metric_timeseries", boom)
+    sql = _vm(hw, category="devtest_no_shutdown_sql", name="srv1/db1")
+    aks = _vm(hw, category="devtest_no_shutdown_aks", name="aks-dev")
+    out = hw.refine_devtest_findings(
+        [sql, aks], uptime_days=14, uptime_threshold=0.95)
+    cats = sorted(f.category for f in out)
+    assert cats == ["devtest_no_shutdown_aks", "devtest_no_shutdown_sql"]
+
+
+def test_refine_no_op_when_no_devtest_findings(hw):
+    # Pure pass-through must not blow up when there's nothing to do.
+    f = hw.Finding(
+        category="unattached_disks", sub_id="x", sub_name="t",
+        rg="rg", name="d1", location="weu",
+        resource_id="/subscriptions/x/.../d1", sku="Premium_LRS",
+    )
+    out = hw.refine_devtest_findings(
+        [f], uptime_days=14, uptime_threshold=0.95)
+    assert out == [f]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+def test_devtest_waste_ratio_is_12h_5d_cadence(hw):
+    # 168 hours/week running today, 60 target (12h × 5d).
+    assert hw.DEVTEST_WASTE_RATIO == pytest.approx(108.0 / 168.0)
+    assert hw.DEVTEST_WASTE_RATIO < 0.65 and hw.DEVTEST_WASTE_RATIO > 0.64

--- a/tools/context-enricher/context_enricher.py
+++ b/tools/context-enricher/context_enricher.py
@@ -61,21 +61,19 @@ CURRENCY_ISO: str = "GBP"
 
 # ---------------------------------------------------------------------------
 # Tag conventions — case-insensitive lookup, first match wins.
+# Single source of truth lives in ``tools/tag_keys.py``; re-exported
+# here so existing call-sites (and ``from context_enricher import
+# ENVIRONMENT_KEYS``) keep working.
 # ---------------------------------------------------------------------------
 
-OWNER_KEYS       = ("owned by", "managed by", "owner", "team", "domain",
-                    "approval group", "support group", "department",
-                    "responsibleteam", "ops_owner")
-CRITICALITY_KEYS = ("business criticality", "criticality", "service tier",
-                    "businesscriticality", "tier", "businesstier")
-ENVIRONMENT_KEYS = ("environment", "env")
-COSTCENTRE_KEYS  = ("cost centre", "cost center", "costcenter", "costcentre",
-                    "cost_centre", "cost_center")
-APP_KEYS         = ("service", "product", "application", "app", "appname",
-                    "applicationname", "project")
-
-# Placeholder values commonly used as placeholders that should be treated as "no value".
-TAG_PLACEHOLDERS = {"untagged", "n/a", "na", "tbc", "tbd", "none", "-", ""}
+from tag_keys import (  # noqa: E402
+    OWNER_KEYS,
+    CRITICALITY_KEYS,
+    ENVIRONMENT_KEYS,
+    COSTCENTRE_KEYS,
+    APP_KEYS,
+    TAG_PLACEHOLDERS,
+)
 
 # Confidence thresholds (£ / month).
 HIGH_GBP_FLOOR = 100.0

--- a/tools/hidden-waste/README.md
+++ b/tools/hidden-waste/README.md
@@ -7,7 +7,7 @@ the guardrails.
 
 ## What it does
 
-1. Runs twelve **Resource Graph** queries in a single pass across the supplied
+1. Runs fifteen **Resource Graph** queries in a single pass across the supplied
    subscriptions:
    - Unattached managed disks (`diskState =~ 'Unattached'` AND no `managedBy`).
    - Unused public IPs (no `ipConfiguration` AND no `natGateway`).
@@ -37,19 +37,41 @@ the guardrails.
    - Oversized premium file shares (parent `kind == 'FileStorage'`,
      `shareQuota >= 1024 GiB`). Refined by `FileCapacity` per-share
      (Average, 30d) — flagged when used <= 50% of quota.
+   - **Dev/test VMs without auto-shutdown.** `environment` / `env` tag
+     in the canonical dev/test value list (`dev`, `test`, `qa`, `uat`,
+     `staging`, `preprod`, `sandbox`, `nonprod`, …), `PowerState/running`,
+     and **no** `microsoft.devtestlab/schedules` `ComputeVmShutdownTask`
+     (Enabled) targeting the VM. AKS-managed (`mc_*`) and Databricks
+     (`databricks-rg-*`) RGs and AKS-spawned (`aks-*`) names are
+     excluded. Refined by ≥ `--devtest-uptime-threshold` (default 0.95)
+     hourly Percentage CPU coverage over `--devtest-uptime-days`
+     (default 14) — same posture as `rightsizing-peak`. Missing metrics
+     keep the candidate, tagged `uptime=unknown`.
+   - **Dev/test SQL DBs not on Serverless.** `microsoft.sql/servers/databases`
+     with env-tag in the dev/test list and service tier not starting with
+     `GP_S_` — provisioned DTU/vCore tiers bill regardless of activity;
+     Serverless General-Purpose is the only auto-pause-capable option.
+   - **Dev/test AKS clusters always-on.** `microsoft.containerservice/managedclusters`
+     with env-tag in the dev/test list and `properties.powerState.code =~ 'Running'`.
+     Pause via `az aks stop`; control-plane and node-pool charges drop to
+     near-zero while stopped.
 2. Pulls 30 days of **actual** £ from the Cost Management `/query` REST API
    (via `az rest`, body sent as a temp file — Windows-quoting-safe). Per-sub
    paging short-circuits as soon as every flagged resource is priced; capped
-   at 5 pages × 5 000 rows for safety.
+   at 5 pages × 5 000 rows for safety. Dev/test categories scale the bill by
+   `108/168 ≈ 0.6429` (the wasted slice vs a 12h × 5d target cadence).
 3. Falls back to **list-price estimates** when Cost Management has no row for
    a flagged resource (e.g. never-attached ASR replica disks, day-old
    snapshots). Disk pricing is hand-coded for P/E tiers in West Europe GBP;
    Standard public IPs at £3 / mo; idle Standard LBs at £15 / mo; premium
    files at £0.16 / GiB-month applied to the *recoverable* slice
-   (`shareQuota - actual_used`).
+   (`shareQuota - actual_used`). Dev/test rows without a CM hit are reported
+   as `unknown` rather than fabricated.
 4. Writes per-category **audit-mode Azure Policy** JSON into `policy/` so
    platform teams can promote the top-3 by £ to deny-mode after a 30-day
-   audit cycle.
+   audit cycle. Dev/test detectors are tag/configuration-based rather than
+   resource-property based, so they don't ship a Policy template — the
+   top-3 selection skips them.
 
 ## Inputs
 

--- a/tools/hidden-waste/hidden_waste.py
+++ b/tools/hidden-waste/hidden_waste.py
@@ -66,6 +66,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from html_sink import write_html, write_index  # noqa: E402
 from finops_currency import detect_currency  # noqa: E402
+from tag_keys import DEVTEST_ENV_VALUES  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Display currency (overridden in main() from CLI / billing-account auto-detect).
@@ -139,6 +140,13 @@ def az_rest(method: str, url: str, body: dict, max_retries: int = 6) -> dict:
 
 GRAPH_URL = ("https://management.azure.com/providers/Microsoft.ResourceGraph/"
              "resources?api-version=2022-10-01")
+
+# Comma-separated, single-quoted KQL list of dev/test environment-tag
+# values, sourced from the shared ``tag_keys`` module so this engine and
+# ``context-enricher`` can never drift. Embedded into the dev/test
+# detector queries below at module-import time.
+_DEVTEST_KQL: str = ",".join(
+    f"'{v}'" for v in sorted(DEVTEST_ENV_VALUES))
 
 QUERIES: dict[str, str] = {
     "unattached_disks": (
@@ -290,6 +298,82 @@ QUERIES: dict[str, str] = {
         "  id=tolower(id), "
         "  sku=accountSku, "
         "  sizeGb=quotaGb"
+    ),
+    # Dev/test auto-shutdown gap (issue #5) — VMs.
+    # ``tagsLow`` re-parses the tag bag with all keys/values lowercased so
+    # the env-tag lookup is case-insensitive (Azure tag keys are case-
+    # preserving but the convention varies per estate). Excludes managed
+    # node-pool RGs (``mc_*`` / ``databricks-rg-*``) and AKS-spawned VM
+    # names so customer-owned VMs are the only candidates. Left-anti
+    # joined against DevTestLab auto-shutdown schedules pointing at this
+    # VM's resource ID.
+    "devtest_no_shutdown_vm": (
+        "Resources "
+        "| where type =~ 'microsoft.devtestlab/schedules' "
+        "| where tostring(properties.taskType) =~ 'ComputeVmShutdownTask' "
+        "| where tostring(properties.status) =~ 'Enabled' "
+        "| extend target = tolower(tostring(properties.targetResourceId)) "
+        "| where isnotempty(target) "
+        "| distinct target "
+        "| join kind=rightanti ( "
+        "    Resources "
+        "    | where type =~ 'microsoft.compute/virtualmachines' "
+        "    | extend rgL = tolower(resourceGroup) "
+        "    | where rgL !startswith 'databricks-rg-' "
+        "    | where rgL !startswith 'mc_' "
+        "    | where tolower(name) !startswith 'aks-' "
+        "    | extend tagsLow = todynamic(tolower(tostring(tags))) "
+        "    | extend env_raw = tostring(coalesce(tagsLow.environment, "
+        "                                         tagsLow.env)) "
+        f"    | where env_raw in ({_DEVTEST_KQL}) "
+        "    | extend power = tostring("
+        "        properties.extended.instanceView.powerState.code) "
+        "    | where power == 'PowerState/running' "
+        "    | extend rid = tolower(id) "
+        "    | project subscriptionId, resourceGroup, name, location, "
+        "              rid, env_raw, "
+        "              vmSize = tostring(properties.hardwareProfile.vmSize) "
+        "  ) on $left.target == $right.rid "
+        "| project subscriptionId, resourceGroup, name, location, "
+        "  id=rid, sku=vmSize, extra=env_raw"
+    ),
+    # Dev/test auto-shutdown gap — Azure SQL DB.
+    # Provisioned (DTU/vCore) tiers bill regardless of activity; only the
+    # Serverless General-Purpose tier (``GP_S_*``) auto-pauses. Flag any
+    # env=dev/test database that isn't Serverless. ``master`` system
+    # databases are excluded — they're billed under the parent server
+    # SKU and aren't independently scalable.
+    "devtest_no_shutdown_sql": (
+        "Resources "
+        "| where type =~ 'microsoft.sql/servers/databases' "
+        "| where tolower(name) !endswith '/master' "
+        "| extend tagsLow = todynamic(tolower(tostring(tags))) "
+        "| extend env_raw = tostring(coalesce(tagsLow.environment, "
+        "                                     tagsLow.env)) "
+        f"| where env_raw in ({_DEVTEST_KQL}) "
+        "| extend tier = tostring(coalesce("
+        "        properties.currentServiceObjectiveName, sku.name)) "
+        "| where tier !startswith 'GP_S_' "
+        "| project subscriptionId, resourceGroup, name, location, "
+        "  id=tolower(id), sku=tier, extra=env_raw"
+    ),
+    # Dev/test auto-shutdown gap — AKS clusters.
+    # Clusters can be paused with ``az aks stop`` (frees the control-
+    # plane and node-pool charges). Flag dev/test clusters that are
+    # currently running.
+    "devtest_no_shutdown_aks": (
+        "Resources "
+        "| where type =~ 'microsoft.containerservice/managedclusters' "
+        "| extend tagsLow = todynamic(tolower(tostring(tags))) "
+        "| extend env_raw = tostring(coalesce(tagsLow.environment, "
+        "                                     tagsLow.env)) "
+        f"| where env_raw in ({_DEVTEST_KQL}) "
+        "| extend power = tostring(properties.powerState.code) "
+        "| where power =~ 'Running' "
+        "| project subscriptionId, resourceGroup, name, location, "
+        "  id=tolower(id), "
+        "  sku=tostring(coalesce(sku.tier, properties.agentPoolProfiles[0].vmSize)), "
+        "  extra=env_raw"
     ),
 }
 
@@ -674,6 +758,90 @@ def refine_paas_findings(raw: list["Finding"],
 
 
 
+# ---------------------------------------------------------------------------
+# Dev/test auto-shutdown gap (issue #5)
+# ---------------------------------------------------------------------------
+
+# Cadence target from the issue: 12h × 5 working days = 60h/week of
+# legitimate runtime versus 24×7 = 168h. Wasted ratio = 108/168.
+# Applied to the 30-day Cost Management bill for the resource.
+DEVTEST_WASTE_RATIO: float = 108.0 / 168.0
+
+# Uptime-evidence window for VMs. Mirrors ``rightsizing-peak``'s
+# 14-day Percentage CPU coverage check.
+DEVTEST_UPTIME_DAYS_DEFAULT: int = 14
+DEVTEST_UPTIME_THRESHOLD_DEFAULT: float = 0.95
+
+
+DEVTEST_VM_CAT = "devtest_no_shutdown_vm"
+DEVTEST_SQL_CAT = "devtest_no_shutdown_sql"
+DEVTEST_AKS_CAT = "devtest_no_shutdown_aks"
+DEVTEST_CATS = frozenset({
+    DEVTEST_VM_CAT, DEVTEST_SQL_CAT, DEVTEST_AKS_CAT,
+})
+
+
+def refine_devtest_findings(raw: list["Finding"],
+                            *,
+                            uptime_days: int,
+                            uptime_threshold: float,
+                            skip_metrics: bool = False) -> list["Finding"]:
+    """Confirm VM dev/test candidates have ≥``uptime_threshold`` 14d uptime.
+
+    Resource Graph already filters to ``PowerState/running`` (snapshot);
+    Azure Monitor's ``Percentage CPU`` (PT1H Average) coverage gives a
+    14-day signal that the VM is *consistently* running rather than
+    "happens to be on right now".
+
+    Best-effort: missing metrics (no permission / throttled) keep the
+    candidate with an explanatory ``extra`` so the report stays honest.
+    SQL and AKS candidates are passed through unchanged — their gap is
+    configurational (provisioned tier / cluster running), not duty-cycle.
+
+    With ``skip_metrics=True`` the metric pass is skipped entirely;
+    every VM candidate is kept and tagged ``metric-skipped``. Different
+    posture from PaaS — the env-tag + no-schedule pair *is* prima-facie
+    waste signal, so dropping silently would lose useful findings.
+    """
+    if not any(f.category in DEVTEST_CATS for f in raw):
+        return raw
+
+    expected = uptime_days * 24
+    metric_failures = 0
+    out: list["Finding"] = []
+    for f in raw:
+        if f.category != DEVTEST_VM_CAT:
+            out.append(f)
+            continue
+        if skip_metrics:
+            f.extra = f"{f.extra} | metric-skipped".strip(" |")
+            out.append(f)
+            continue
+        vals = az_metric_timeseries(
+            f.resource_id, metric="Percentage CPU",
+            aggregation="Average", days=uptime_days, interval="PT1H")
+        if vals is None:
+            metric_failures += 1
+            f.extra = f"{f.extra} | uptime=unknown".strip(" |")
+            out.append(f)
+            continue
+        coverage = (len(vals) / expected) if expected else 0.0
+        if coverage >= uptime_threshold:
+            f.extra = (f"{f.extra} | uptime "
+                       f"{coverage * 100:.0f}% / {uptime_days}d").strip(" |")
+            out.append(f)
+        # else drop — VM isn't actually always-on
+
+    if metric_failures:
+        print(f"  ⚠ {metric_failures} dev/test VM(s) kept without uptime "
+              f"verification (metrics unavailable; check Monitoring "
+              f"Reader RBAC).", flush=True)
+    return out
+
+
+
+
+
 def fetch_resource_costs(sub_id: str, days: int = 30,
                          wanted: set[str] | None = None,
                          max_pages: int = 5) -> dict[str, float]:
@@ -813,6 +981,9 @@ CATEGORY_LABELS = {
     "storage_cold_tier":          "Hot-tier storage accounts (cold workload)",
     "storage_untouched_container": "Untouched blob containers (>90d)",
     "storage_oversize_premium":   "Oversized premium file shares",
+    "devtest_no_shutdown_vm":     "Dev/test VMs without auto-shutdown",
+    "devtest_no_shutdown_sql":    "Dev/test SQL DBs not on Serverless tier",
+    "devtest_no_shutdown_aks":    "Dev/test AKS clusters always-on",
 }
 
 
@@ -821,7 +992,13 @@ def annotate_cost(finding: Finding, cost_map: dict[str, float],
     rid = finding.resource_id.lower()
     if rid in cost_map and cost_map[rid] > 0:
         # last-N-days cost → monthly equivalent
-        finding.monthly_gbp = cost_map[rid] * 30.0 / max(days, 1)
+        monthly = cost_map[rid] * 30.0 / max(days, 1)
+        if finding.category in DEVTEST_CATS:
+            # Only the "wasted" slice (24×7 today vs 12h × 5d target)
+            # is recoverable — see DEVTEST_WASTE_RATIO.
+            finding.monthly_gbp = monthly * DEVTEST_WASTE_RATIO
+        else:
+            finding.monthly_gbp = monthly
         finding.cost_source = "cost_mgmt"
         return
     # fallbacks per category
@@ -878,6 +1055,12 @@ def annotate_cost(finding: Finding, cost_map: dict[str, float],
     elif finding.category == "idle_container_app":
         # Same posture as idle_app_service_plan — CM has CA resource
         # IDs but the consumption-vs-dedicated split can hide rows.
+        finding.monthly_gbp = 0.0
+        finding.cost_source = "unknown"
+    elif finding.category in DEVTEST_CATS:
+        # Cost Management had no row for the resource — common for
+        # newly-deployed dev/test workloads or those under
+        # consolidated-billing children. Don't fabricate savings.
         finding.monthly_gbp = 0.0
         finding.cost_source = "unknown"
     else:
@@ -946,10 +1129,13 @@ def write_md(path: Path, findings: list[Finding], sub_count: int) -> None:
             f"{gbp(c_total)} | {gbp(c_total * 12)} |"
         )
 
-    # Top 3 worst classes for Azure Policy starter pack
+    # Top 3 worst classes for Azure Policy starter pack — only those
+    # that have a template (env-tag categories don't lend themselves to
+    # a clean Policy rule, so they're excluded from this section).
     cat_costs = sorted(
         ((cat, sum(f.monthly_gbp for f in by_cat.get(cat, [])))
-         for cat in QUERIES.keys() if by_cat.get(cat)),
+         for cat in QUERIES.keys()
+         if by_cat.get(cat) and cat in POLICY_TEMPLATES),
         key=lambda t: -t[1],
     )
     top3 = [c for c, _ in cat_costs[:3]]
@@ -1299,6 +1485,8 @@ def run(subs: list[str], out_dir: Path,
         asp_idle_cpu_p95_max: float = ASP_IDLE_CPU_P95_MAX_DEFAULT,
         ca_idle_days: int = CA_IDLE_DAYS_DEFAULT,
         ca_idle_requests_max: int = CA_IDLE_REQUESTS_MAX_DEFAULT,
+        devtest_uptime_days: int = DEVTEST_UPTIME_DAYS_DEFAULT,
+        devtest_uptime_threshold: float = DEVTEST_UPTIME_THRESHOLD_DEFAULT,
         skip_metrics: bool = False):
     out_dir.mkdir(parents=True, exist_ok=True)
     date = datetime.now(timezone.utc).strftime("%Y%m%d")
@@ -1356,6 +1544,21 @@ def run(subs: list[str], out_dir: Path,
             skip_metrics=skip_metrics,
         )
 
+    # Dev/test auto-shutdown gap (issue #5): VMs already passed the
+    # PowerState/running snapshot in ARG; verify ≥95% uptime over the
+    # last 14 days via Percentage CPU coverage. SQL/AKS pass through
+    # unchanged — their gap is configurational.
+    if any(f.category in DEVTEST_CATS for f in raw_findings):
+        print("[engine] Verifying dev/test VM uptime via Azure Monitor "
+              "(best-effort; missing metrics are kept and tagged)…",
+              flush=True)
+        raw_findings = refine_devtest_findings(
+            raw_findings,
+            uptime_days=devtest_uptime_days,
+            uptime_threshold=devtest_uptime_threshold,
+            skip_metrics=skip_metrics,
+        )
+
     # Enrich with actual £ from Cost Management (one query per sub,
     # short-circuited as soon as every flagged resource for that sub
     # has been priced).
@@ -1398,7 +1601,8 @@ def run(subs: list[str], out_dir: Path,
          for cat in QUERIES.keys()),
         key=lambda t: -t[1],
     )
-    top3 = [c for c, v in cat_costs[:3] if v > 0]
+    top3 = [c for c, v in cat_costs[:3]
+            if v > 0 and c in POLICY_TEMPLATES]
     tool_dir = Path(__file__).resolve().parent
     write_policy_starter_pack(tool_dir, top3)
 
@@ -1407,8 +1611,8 @@ def run(subs: list[str], out_dir: Path,
     print(f"  - {md_path}")
     print(f"  - {html_path}")
     print(f"  - {csv_path}")
-    print(f"  - {tool_dir / 'policy'}/  (audit-mode policies for all "
-          f"12 classes)")
+    print(f"  - {tool_dir / 'policy'}/  (audit-mode policies for "
+          f"{len(POLICY_TEMPLATES)} classes)")
     print(f"[engine] Total flagged: {len(raw_findings):,} resources, "
           f"~{gbp(total_monthly)}/mo (~{gbp(total_monthly * 12)}/yr).")
 
@@ -1483,6 +1687,15 @@ def main():
                     default=CA_IDLE_DAYS_DEFAULT,
                     help="Container Apps observation window (days). "
                          "Default: 14.")
+    ap.add_argument("--devtest-uptime-days", type=int,
+                    default=DEVTEST_UPTIME_DAYS_DEFAULT,
+                    help="Window (days) used to confirm dev/test VMs "
+                         "are consistently running. Default: 14.")
+    ap.add_argument("--devtest-uptime-threshold", type=float,
+                    default=DEVTEST_UPTIME_THRESHOLD_DEFAULT,
+                    help="Min fraction of hourly Percentage CPU samples "
+                         "required to flag a dev/test VM as always-on "
+                         "(0.0–1.0). Default: 0.95.")
     ap.add_argument("--skip-metrics", action="store_true",
                     help="Skip Azure Monitor metric calls for metric-"
                          "dependent PaaS rightsizing checks; those "
@@ -1515,6 +1728,8 @@ def main():
         asp_idle_cpu_p95_max=args.asp_idle_cpu_p95_max,
         ca_idle_days=args.ca_idle_days,
         ca_idle_requests_max=args.ca_idle_requests_max,
+        devtest_uptime_days=args.devtest_uptime_days,
+        devtest_uptime_threshold=args.devtest_uptime_threshold,
         skip_metrics=args.skip_metrics)
 
 

--- a/tools/tag_keys.py
+++ b/tools/tag_keys.py
@@ -1,0 +1,80 @@
+"""tag_keys.py — Shared resource-tag conventions across FinOps Engine tools.
+
+Single source of truth for the case-insensitive tag-key tuples that
+``context-enricher`` (and now ``hidden-waste``) consult when reading
+``owner`` / ``criticality`` / ``environment`` / ``cost-centre`` /
+``application`` from Azure Resource tags.
+
+Keep these tuples ordered most-specific → most-generic; the per-tool
+helpers iterate in declared order and stop at the first non-empty,
+non-placeholder match.
+
+No third-party dependencies — uses the Python standard library only.
+"""
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Tag-key conventions (case-insensitive lookup, first match wins)
+# ---------------------------------------------------------------------------
+
+OWNER_KEYS: tuple[str, ...] = (
+    "owned by", "managed by", "owner", "team", "domain",
+    "approval group", "support group", "department",
+    "responsibleteam", "ops_owner",
+)
+
+CRITICALITY_KEYS: tuple[str, ...] = (
+    "business criticality", "criticality", "service tier",
+    "businesscriticality", "tier", "businesstier",
+)
+
+ENVIRONMENT_KEYS: tuple[str, ...] = ("environment", "env")
+
+COSTCENTRE_KEYS: tuple[str, ...] = (
+    "cost centre", "cost center", "costcenter", "costcentre",
+    "cost_centre", "cost_center",
+)
+
+APP_KEYS: tuple[str, ...] = (
+    "service", "product", "application", "app", "appname",
+    "applicationname", "project",
+)
+
+# ---------------------------------------------------------------------------
+# Tag-value conventions
+# ---------------------------------------------------------------------------
+
+# Common placeholder values that should be treated as "no value".
+TAG_PLACEHOLDERS: frozenset[str] = frozenset({
+    "untagged", "n/a", "na", "tbc", "tbd", "none", "-", "",
+})
+
+# Environment-tag values that signal a non-production workload — the
+# population of resources eligible for dev/test cost optimisations
+# (auto-shutdown, serverless tiers, smaller SKUs). Lower-cased here for
+# case-insensitive matching at the call site.
+DEVTEST_ENV_VALUES: frozenset[str] = frozenset({
+    "dev", "develop", "development",
+    "test", "testing",
+    "qa", "quality",
+    "uat", "useracceptance", "user-acceptance",
+    "stg", "stage", "staging",
+    "preprod", "pre-prod", "pre-production", "preproduction",
+    "sandbox", "sbx", "sand",
+    "devtest", "dev-test", "dev/test",
+    "nonprod", "non-prod", "non-production", "nonproduction",
+})
+
+
+def is_devtest(value: str | None) -> bool:
+    """Return True if an environment-tag value designates a non-prod workload.
+
+    Matching is case-insensitive and ignores surrounding whitespace; an
+    empty / placeholder value returns False.
+    """
+    if not value:
+        return False
+    v = value.strip().lower()
+    if not v or v in TAG_PLACEHOLDERS:
+        return False
+    return v in DEVTEST_ENV_VALUES


### PR DESCRIPTION
Closes #5.

## What this adds

Three new categories in `hidden-waste` for dev/test workloads that bill 24×7 against a target 12h × 5d cadence:

| Category | Detection (Resource Graph) | Refinement |
|---|---|---|
| `devtest_no_shutdown_vm` | env tag in dev/test list, `PowerState/running`, **no** matching `microsoft.devtestlab/schedules` `ComputeVmShutdownTask` (Enabled). Excludes `mc_*`, `databricks-rg-*`, `aks-*`. | ≥95% hourly Percentage CPU coverage over last 14d (Azure Monitor). Best-effort — missing metrics keep candidate tagged `uptime=unknown`. |
| `devtest_no_shutdown_sql` | `microsoft.sql/servers/databases` with env tag in dev/test list, service tier **not** starting with `GP_S_` (Serverless). | None — provisioned tiers always bill regardless of activity. |
| `devtest_no_shutdown_aks` | `microsoft.containerservice/managedclusters` with env tag in dev/test list and `properties.powerState.code =~ 'Running'`. | None — `az aks stop` pauses both control-plane and node-pool charges. |

## Savings calculation

Per the issue: 12h × 5d = 60h target, 24×7 = 168h current → recoverable = 108/168 ≈ **0.6429** of the 30-day Cost Management bill. Rows without a CM hit are reported as `unknown` rather than fabricated.

## Shared tag conventions

`OWNER_KEYS`, `CRITICALITY_KEYS`, `ENVIRONMENT_KEYS`, `COSTCENTRE_KEYS`, `APP_KEYS`, `TAG_PLACEHOLDERS` and the new `DEVTEST_ENV_VALUES` set moved to `tools/tag_keys.py`. `context-enricher` re-imports them so both engines stay in lock-step on what counts as "dev/test". The KQL queries embed the canonical value list at module-import time so no drift is possible.

## CLI

```
--devtest-uptime-days       (default 14)
--devtest-uptime-threshold  (default 0.95)
```

## Tests

- 14 new tests in `tests/test_hidden_waste_devtest.py` covering registry, query content, waste-ratio applied to CM bill, fallback to `unknown`, and all four refine paths (high-coverage / low-coverage / missing metrics / `--skip-metrics`).
- All 85 tests pass (`pytest tests/`).

## Notes

- Dev/test categories don't ship a Policy template — env-tag based audits don't translate cleanly to a Policy rule. Top-3 selection in the policy starter pack now skips categories without a template, so the README's `policy/<cat>.audit.json` reference always resolves.
- VM detector uses `kind=rightanti` so we only emit VMs that *don't* have a DevTestLab shutdown schedule pointing at them.